### PR TITLE
Refactor/modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@bitcoin-design/bitcoin-icons-react": "^0.1.9",
+    "@headlessui/react": "^1.7.15",
     "@heroicons/react": "^2.0.18",
     "axios": "^1.4.0",
     "i18next": "^23.3.0",

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -24,7 +24,7 @@ const AmountInput: FC<Props> = ({
 }) => {
   const { t } = useTranslation();
   const [amountInput, setAmountInput] = useState<string>(
-    amount ? `${amount}` : ""
+    amount ? `${amount}` : "",
   );
   const { unit, toggleUnit } = useContext(AppContext);
 
@@ -32,7 +32,7 @@ const AmountInput: FC<Props> = ({
     let formattedValue = amountInput;
     if (unit === Unit.BTC && formattedValue) {
       formattedValue = new Intl.NumberFormat("en-US").format(
-        convertBtcToSat(+formattedValue)
+        convertBtcToSat(+formattedValue),
       );
     } else {
       // remove separators
@@ -69,6 +69,7 @@ const AmountInput: FC<Props> = ({
       <label className="label-underline" htmlFor={register.name}>
         {t("wallet.amount")}
       </label>
+
       <div className="flex">
         <input
           {...register}
@@ -79,13 +80,15 @@ const AmountInput: FC<Props> = ({
           onChange={onChangeHandler}
           disabled={disabled}
         />
-        <span
+
+        <button
+          type="button"
           className="ml-6 flex w-4/12 items-center justify-center rounded p-1 shadow-md dark:bg-gray-600"
           onClick={toggleHandler}
         >
           {unit}
           <ArrowsRightLeftIcon className="ml-1 h-5 w-5 text-black dark:text-white" />
-        </span>
+        </button>
       </div>
 
       <p

--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -191,7 +191,8 @@
       "display_sats": "Display SATS",
       "home": "Home",
       "logout": "Log out",
-      "settings": "Settings"
+      "settings": "Settings",
+      "cancel": "Cancel"
     },
     "settings": {
       "cancel": "Cancel",

--- a/src/layouts/Modal.tsx
+++ b/src/layouts/Modal.tsx
@@ -91,7 +91,7 @@ const Modal: FC<Props> = ({
                     </div>
                   </div>
 
-                  <div className="bg-gray-50 dark:bg-zinc-900 px-4 py-3 sm:flex justify-between sm:px-6">
+                  <div className="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:flex justify-between sm:px-6">
                     {backFunc ? (
                       <button
                         type="reset"

--- a/src/layouts/Modal.tsx
+++ b/src/layouts/Modal.tsx
@@ -1,21 +1,21 @@
-import { Fragment, useRef, useState } from "react";
+import { Fragment, useRef } from "react";
 import { Dialog, Transition } from "@headlessui/react";
-import { FC, useCallback, useEffect } from "react";
+import { FC } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 
 type Props = {
   children?: React.ReactNode;
-  closeable?: boolean;
+  // closeable?: boolean;
   closeFunc: () => void;
   backFunc?: () => void;
-  submitFunc: any;
+  submitFunc?: () => void;
   title: string;
   submitTitle?: string;
 };
 
 // export default function Modal() {
 const Modal: FC<Props> = ({
-  closeable = true,
+  // closeable = true,
   closeFunc,
   backFunc,
   children,
@@ -62,7 +62,7 @@ const Modal: FC<Props> = ({
                 <form
                   onSubmit={(event) => {
                     event.preventDefault();
-                    submitFunc();
+                    submitFunc && submitFunc();
                   }}
                 >
                   <div className="absolute right-0 top-0 hidden pr-4 pt-4 sm:block">

--- a/src/layouts/Modal.tsx
+++ b/src/layouts/Modal.tsx
@@ -1,9 +1,8 @@
 import { Fragment, useRef } from "react";
 import { Dialog, Transition } from "@headlessui/react";
-import { FC } from "react";
+import type { FC } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { useTranslation } from "react-i18next";
-import { log } from "console";
 
 type Props = {
   children?: React.ReactNode;
@@ -12,7 +11,7 @@ type Props = {
   backFunc?: () => void;
   submitFunc?: () => void;
   title: string;
-  submitTitle?: string;
+  submitLabel?: string;
 };
 
 const Modal: FC<Props> = ({
@@ -21,7 +20,7 @@ const Modal: FC<Props> = ({
   backFunc,
   children,
   title,
-  submitTitle,
+  submitLabel,
   submitFunc,
 }) => {
   const { t } = useTranslation();
@@ -62,7 +61,6 @@ const Modal: FC<Props> = ({
               <Dialog.Panel className="relative transform  overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
                 <form
                   onSubmit={(event) => {
-                    console.log("submit");
                     event.preventDefault();
                     submitFunc && submitFunc();
                   }}
@@ -87,6 +85,7 @@ const Modal: FC<Props> = ({
                         >
                           {title}
                         </Dialog.Title>
+
                         <div className="mt-2">{children}</div>
                       </div>
                     </div>
@@ -109,12 +108,12 @@ const Modal: FC<Props> = ({
                     )}
 
                     <div className="sm:flex sm:flex-row-reverse">
-                      {submitTitle && (
+                      {submitLabel && (
                         <button
                           type="submit"
                           className="inline-flex w-full bg-yellow-500 hover:bg-yellow-400 justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm sm:ml-3 sm:w-auto"
                         >
-                          {submitTitle}
+                          {submitLabel}
                         </button>
                       )}
 

--- a/src/layouts/Modal.tsx
+++ b/src/layouts/Modal.tsx
@@ -33,7 +33,7 @@ const Modal: FC<Props> = ({
         as="div"
         className="relative z-10"
         initialFocus={cancelButtonRef}
-        onClose={closeFunc}
+        onClose={() => closeFunc()}
       >
         <Transition.Child
           as={Fragment}
@@ -69,7 +69,7 @@ const Modal: FC<Props> = ({
                     <button
                       type="button"
                       className="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                      onClick={closeFunc}
+                      onClick={() => closeFunc()}
                     >
                       <span className="sr-only">Close</span>
                       <XMarkIcon className="h-6 w-6" aria-hidden="true" />
@@ -119,7 +119,7 @@ const Modal: FC<Props> = ({
                       <button
                         type="reset"
                         className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
-                        onClick={closeFunc}
+                        onClick={() => closeFunc()}
                         ref={cancelButtonRef}
                       >
                         Cancel

--- a/src/layouts/Modal.tsx
+++ b/src/layouts/Modal.tsx
@@ -3,6 +3,7 @@ import { Dialog, Transition } from "@headlessui/react";
 import type { FC } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { useTranslation } from "react-i18next";
+import ButtonWithSpinner from "../components/ButtonWithSpinner/ButtonWithSpinner";
 
 type Props = {
   children?: React.ReactNode;
@@ -12,10 +13,12 @@ type Props = {
   submitFunc?: () => void;
   title: string;
   submitLabel?: string;
+  isLoading?: boolean;
 };
 
 const Modal: FC<Props> = ({
   // closeable = true,
+  isLoading = false,
   closeFunc,
   backFunc,
   children,
@@ -109,12 +112,13 @@ const Modal: FC<Props> = ({
 
                     <div className="sm:flex sm:flex-row-reverse">
                       {submitLabel && (
-                        <button
+                        <ButtonWithSpinner
                           type="submit"
+                          loading={isLoading}
                           className="inline-flex w-full bg-yellow-500 hover:bg-yellow-400 justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm sm:ml-3 sm:w-auto"
                         >
                           {submitLabel}
-                        </button>
+                        </ButtonWithSpinner>
                       )}
 
                       <button

--- a/src/layouts/Modal.tsx
+++ b/src/layouts/Modal.tsx
@@ -58,7 +58,7 @@ const Modal: FC<Props> = ({
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative transform  overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
                 <form
                   onSubmit={(event) => {
                     event.preventDefault();

--- a/src/layouts/Modal.tsx
+++ b/src/layouts/Modal.tsx
@@ -1,22 +1,27 @@
 import { Fragment, useRef, useState } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import { FC, useCallback, useEffect } from "react";
+import { XMarkIcon } from "@heroicons/react/24/outline";
 
 type Props = {
   children?: React.ReactNode;
   closeable?: boolean;
-  close: () => void;
+  closeFunc: () => void;
+  backFunc?: () => void;
+  submitFunc: any;
   title: string;
-  showFooter?: boolean;
+  submitTitle?: string;
 };
 
 // export default function Modal() {
 const Modal: FC<Props> = ({
   closeable = true,
-  showFooter = true,
-  close,
+  closeFunc,
+  backFunc,
   children,
   title,
+  submitTitle,
+  submitFunc,
 }) => {
   // const [open, setOpen] = useState(true);
 
@@ -28,7 +33,7 @@ const Modal: FC<Props> = ({
         as="div"
         className="relative z-10"
         initialFocus={cancelButtonRef}
-        onClose={close}
+        onClose={closeFunc}
       >
         <Transition.Child
           as={Fragment}
@@ -54,38 +59,74 @@ const Modal: FC<Props> = ({
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
               <Dialog.Panel className="relative transform  overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-                <div className="bg-white px-4 pb-4 pt-5 dark:bg-gray-800 dark:text-white sm:p-6 sm:pb-4">
-                  <div className="sm:flex sm:items-start">
-                    <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
-                      <Dialog.Title
-                        as="h3"
-                        className="text-base font-semibold leading-6 text-gray-900 dark:text-white"
-                      >
-                        {title}
-                      </Dialog.Title>
-                      <div className="mt-2">{children}</div>
-                    </div>
-                  </div>
-                </div>
-                {showFooter && (
-                  <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
+                <form
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    submitFunc();
+                  }}
+                >
+                  <div className="absolute right-0 top-0 hidden pr-4 pt-4 sm:block">
                     <button
                       type="button"
-                      className="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:ml-3 sm:w-auto"
-                      onClick={() => console.log("SUBMIT")}
+                      className="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                      onClick={closeFunc}
                     >
-                      Deactivate
-                    </button>
-                    <button
-                      type="reset"
-                      className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
-                      onClick={() => close()}
-                      ref={cancelButtonRef}
-                    >
-                      Cancel
+                      <span className="sr-only">Close</span>
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                     </button>
                   </div>
-                )}
+
+                  <div className="bg-white px-4 pb-4 pt-5 dark:bg-gray-800 dark:text-white sm:p-6 sm:pb-4">
+                    <div className="sm:flex sm:items-start">
+                      <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
+                        <Dialog.Title
+                          as="h3"
+                          className="text-base font-semibold leading-6 text-gray-900 dark:text-white"
+                        >
+                          {title}
+                        </Dialog.Title>
+                        <div className="mt-2">{children}</div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="bg-gray-50 px-4 py-3 sm:flex justify-between sm:px-6">
+                    {backFunc ? (
+                      <button
+                        type="reset"
+                        className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
+                        onClick={backFunc}
+                        ref={cancelButtonRef}
+                      >
+                        BACK
+                      </button>
+                    ) : (
+                      <span>
+                        {/* flexbox needs an empty placeholder here to keep the layout */}
+                      </span>
+                    )}
+
+                    <div className="sm:flex sm:flex-row-reverse">
+                      {submitTitle && (
+                        <button
+                          type="submit"
+                          className="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:ml-3 sm:w-auto"
+                        >
+                          {submitTitle}
+                        </button>
+                      )}
+
+                      <button
+                        type="reset"
+                        className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
+                        onClick={closeFunc}
+                        ref={cancelButtonRef}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                </form>
               </Dialog.Panel>
             </Transition.Child>
           </div>

--- a/src/layouts/Modal.tsx
+++ b/src/layouts/Modal.tsx
@@ -2,6 +2,8 @@ import { Fragment, useRef } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import { FC } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
+import { useTranslation } from "react-i18next";
+import { log } from "console";
 
 type Props = {
   children?: React.ReactNode;
@@ -13,7 +15,6 @@ type Props = {
   submitTitle?: string;
 };
 
-// export default function Modal() {
 const Modal: FC<Props> = ({
   // closeable = true,
   closeFunc,
@@ -23,7 +24,7 @@ const Modal: FC<Props> = ({
   submitTitle,
   submitFunc,
 }) => {
-  // const [open, setOpen] = useState(true);
+  const { t } = useTranslation();
 
   const cancelButtonRef = useRef(null);
 
@@ -61,6 +62,7 @@ const Modal: FC<Props> = ({
               <Dialog.Panel className="relative transform  overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
                 <form
                   onSubmit={(event) => {
+                    console.log("submit");
                     event.preventDefault();
                     submitFunc && submitFunc();
                   }}
@@ -68,10 +70,10 @@ const Modal: FC<Props> = ({
                   <div className="absolute right-0 top-0 hidden pr-4 pt-4 sm:block">
                     <button
                       type="button"
-                      className="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                      className="rounded-md bg-white dark:bg-zinc-900 text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
                       onClick={() => closeFunc()}
                     >
-                      <span className="sr-only">Close</span>
+                      <span className="sr-only">{t("navigation.cancel")}</span>
                       <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                     </button>
                   </div>
@@ -90,7 +92,7 @@ const Modal: FC<Props> = ({
                     </div>
                   </div>
 
-                  <div className="bg-gray-50 px-4 py-3 sm:flex justify-between sm:px-6">
+                  <div className="bg-gray-50 dark:bg-zinc-900 px-4 py-3 sm:flex justify-between sm:px-6">
                     {backFunc ? (
                       <button
                         type="reset"
@@ -98,7 +100,7 @@ const Modal: FC<Props> = ({
                         onClick={backFunc}
                         ref={cancelButtonRef}
                       >
-                        BACK
+                        {t("navigation.back")}
                       </button>
                     ) : (
                       <span>
@@ -110,7 +112,7 @@ const Modal: FC<Props> = ({
                       {submitTitle && (
                         <button
                           type="submit"
-                          className="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:ml-3 sm:w-auto"
+                          className="inline-flex w-full bg-yellow-500 hover:bg-yellow-400 justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm sm:ml-3 sm:w-auto"
                         >
                           {submitTitle}
                         </button>
@@ -118,11 +120,11 @@ const Modal: FC<Props> = ({
 
                       <button
                         type="reset"
-                        className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
+                        className="mt-3 inline-flex w-full justify-center rounded-md px-3 py-2 text-sm font-semibold shadow-sm sm:mt-0 sm:w-auto dark:text-white dark:bg-gray-500"
                         onClick={() => closeFunc()}
                         ref={cancelButtonRef}
                       >
-                        Cancel
+                        {t("navigation.cancel")}
                       </button>
                     </div>
                   </div>

--- a/src/layouts/Modal.tsx
+++ b/src/layouts/Modal.tsx
@@ -1,0 +1,98 @@
+import { Fragment, useRef, useState } from "react";
+import { Dialog, Transition } from "@headlessui/react";
+import { FC, useCallback, useEffect } from "react";
+
+type Props = {
+  children?: React.ReactNode;
+  closeable?: boolean;
+  close: () => void;
+  title: string;
+  showFooter?: boolean;
+};
+
+// export default function Modal() {
+const Modal: FC<Props> = ({
+  closeable = true,
+  showFooter = true,
+  close,
+  children,
+  title,
+}) => {
+  // const [open, setOpen] = useState(true);
+
+  const cancelButtonRef = useRef(null);
+
+  return (
+    <Transition.Root show as={Fragment}>
+      <Dialog
+        as="div"
+        className="relative z-10"
+        initialFocus={cancelButtonRef}
+        onClose={close}
+      >
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 z-10 overflow-y-auto">
+          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+              enterTo="opacity-100 translate-y-0 sm:scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+              leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            >
+              <Dialog.Panel className="sm:max-w-lg relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8">
+                <div className="bg-white px-4 pb-4 pt-5 dark:bg-gray-800 dark:text-white sm:p-6 sm:pb-4">
+                  <div className="sm:flex sm:items-start">
+                    <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
+                      <Dialog.Title
+                        as="h3"
+                        className="text-base font-semibold leading-6 text-gray-900 dark:text-white"
+                      >
+                        {title}
+                      </Dialog.Title>
+                      <div className="mt-2">{children}</div>
+                    </div>
+                  </div>
+                </div>
+                {showFooter && (
+                  <div className="bg-gray-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
+                    <button
+                      type="button"
+                      className="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:ml-3 sm:w-auto"
+                      onClick={() => console.log("SUBMIT")}
+                    >
+                      Deactivate
+                    </button>
+                    <button
+                      type="reset"
+                      className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
+                      onClick={() => close()}
+                      ref={cancelButtonRef}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                )}
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+};
+
+export default Modal;

--- a/src/layouts/Modal.tsx
+++ b/src/layouts/Modal.tsx
@@ -68,7 +68,7 @@ const Modal: FC<Props> = ({
                   <div className="absolute right-0 top-0 hidden pr-4 pt-4 sm:block">
                     <button
                       type="button"
-                      className="rounded-md bg-white dark:bg-zinc-900 text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                      className="rounded-md bg-gray-300 dark:bg-zinc-900 text-black dark:text-white  hover:text-gray-500 hover:dark:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
                       onClick={() => closeFunc()}
                     >
                       <span className="sr-only">{t("navigation.cancel")}</span>

--- a/src/layouts/Modal.tsx
+++ b/src/layouts/Modal.tsx
@@ -81,7 +81,7 @@ const Modal: FC<Props> = ({
 
                   <div className="bg-white px-4 pb-4 pt-5 dark:bg-gray-800 dark:text-white sm:p-6 sm:pb-4">
                     <div className="sm:flex sm:items-start">
-                      <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
+                      <div className="mt-3 text-center sm:mt-0 sm:text-left w-full">
                         <Dialog.Title
                           as="h3"
                           className="text-lg font-semibold leading-6 text-gray-900 dark:text-white"

--- a/src/layouts/Modal.tsx
+++ b/src/layouts/Modal.tsx
@@ -53,7 +53,7 @@ const Modal: FC<Props> = ({
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="sm:max-w-lg relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8">
+              <Dialog.Panel className="relative transform  overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
                 <div className="bg-white px-4 pb-4 pt-5 dark:bg-gray-800 dark:text-white sm:p-6 sm:pb-4">
                   <div className="sm:flex sm:items-start">
                     <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">

--- a/src/layouts/Modal.tsx
+++ b/src/layouts/Modal.tsx
@@ -84,7 +84,7 @@ const Modal: FC<Props> = ({
                       <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
                         <Dialog.Title
                           as="h3"
-                          className="text-base font-semibold leading-6 text-gray-900 dark:text-white"
+                          className="text-lg font-semibold leading-6 text-gray-900 dark:text-white"
                         >
                           {title}
                         </Dialog.Title>

--- a/src/layouts/ModalDialog.tsx
+++ b/src/layouts/ModalDialog.tsx
@@ -41,16 +41,17 @@ const ModalDialog: FC<Props> = ({ closeable = true, close, children }) => {
   return (
     <ModalBackground>
       <div className="xl:max-w-screen-sm flex h-screen max-h-full w-screen flex-col overflow-y-auto rounded-lg bg-white pb-4 text-center shadow-xl dark:bg-gray-800 dark:text-white md:h-auto md:w-4/5 lg:w-1/2 xl:mx-5 xl:w-2/5">
-        <div className="flex pr-2 pt-1">
+        <div className="relative">
           <button
             onClick={closeModal}
-            className={`ml-auto mt-1 flex h-7 w-7 items-end ${
+            className={`aboslute right-2 top-2 h-7 w-7 ${
               closeable ? "" : "invisible"
             }`}
           >
             <XMarkIcon className="h-full w-full" />
           </button>
         </div>
+
         <div className="flex h-full flex-col justify-center px-5">
           {children}
         </div>

--- a/src/layouts/ModalDialog.tsx
+++ b/src/layouts/ModalDialog.tsx
@@ -44,7 +44,7 @@ const ModalDialog: FC<Props> = ({ closeable = true, close, children }) => {
         <div className="relative">
           <button
             onClick={closeModal}
-            className={`aboslute right-2 top-2 h-7 w-7 ${
+            className={`absolute right-2 top-2 h-7 w-7 ${
               closeable ? "" : "invisible"
             }`}
           >

--- a/src/pages/Home/ListChannelModal/Channel.tsx
+++ b/src/pages/Home/ListChannelModal/Channel.tsx
@@ -45,11 +45,11 @@ const Channel: FC<Props> = ({
   };
 
   return (
-    <li className="bg-gray-200 p-3 shadow-inner hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600">
-      <div
-        className="flex justify-between border-b border-gray-500 pb-2"
-        onClick={clickHandler}
-      >
+    <li
+      onClick={clickHandler}
+      className="cursor-pointer bg-gray-200 p-3 shadow-inner hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 border-b border-gray-500"
+    >
+      <div className="flex justify-between">
         <span>{channel.peer_alias}</span>
         {showDetails && <ChevronUpIcon className="h-6 w-6" />}
         {!showDetails && <ChevronDownIcon className="h-6 w-6" />}

--- a/src/pages/Home/ListChannelModal/ListChannelModal.tsx
+++ b/src/pages/Home/ListChannelModal/ListChannelModal.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
 import Message from "../../../components/Message";
-import ModalDialog from "../../../layouts/ModalDialog";
+import Modal from "../../../layouts/Modal";
 import { LightningChannel } from "../../../models/lightning-channel";
 import { AppContext } from "../../../context/app-context";
 import { checkError } from "../../../utils/checkError";
@@ -54,7 +54,7 @@ const ListChannelModal: FC<Props> = ({ onClose }) => {
             channel_id: channelId,
             force_close: forceClose,
           },
-        }
+        },
       )
       .then(() => {
         toast.success(t("home.channel_closed"), { theme });
@@ -67,10 +67,7 @@ const ListChannelModal: FC<Props> = ({ onClose }) => {
   };
 
   return createPortal(
-    <ModalDialog close={onClose}>
-      <h2 className="mb-2 text-lg font-bold">
-        {t("home.current_open_channels")}
-      </h2>
+    <Modal closeFunc={onClose} title={t("home.current_open_channels")}>
       {isLoading && (
         <div className="my-2 flex justify-center">
           <LoadingSpinner />
@@ -87,8 +84,8 @@ const ListChannelModal: FC<Props> = ({ onClose }) => {
         />
       )}
       {error && <Message message={error} />}
-    </ModalDialog>,
-    MODAL_ROOT
+    </Modal>,
+    MODAL_ROOT,
   );
 };
 

--- a/src/pages/Home/OpenChannelModal.tsx
+++ b/src/pages/Home/OpenChannelModal.tsx
@@ -1,4 +1,3 @@
-import { LinkIcon } from "@heroicons/react/24/outline";
 import AvailableBalance from "components/AvailableBalance";
 import { ChangeEvent, FC, useContext, useState } from "react";
 import { createPortal } from "react-dom";
@@ -6,15 +5,14 @@ import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
 import AmountInput from "../../components/AmountInput";
-import ButtonWithSpinner from "../../components/ButtonWithSpinner/ButtonWithSpinner";
 import InputField from "../../components/InputField";
 import Message from "../../components/Message";
 import { AppContext } from "../../context/app-context";
-import ModalDialog from "../../layouts/ModalDialog";
 import { MODAL_ROOT } from "../../utils";
 import { checkError } from "../../utils/checkError";
 import { convertMSatToSat, stringToNumber } from "../../utils/format";
 import { instance } from "../../utils/interceptor";
+import Modal from "../../layouts/Modal";
 
 interface IFormInputs {
   nodeUri: string;
@@ -38,7 +36,7 @@ const OpenChannelModal: FC<Props> = ({ balance, onClose }) => {
   const {
     register,
     handleSubmit,
-    formState: { errors, isValid },
+    formState: { errors },
   } = useForm<IFormInputs>({
     mode: "onChange",
   });
@@ -55,7 +53,7 @@ const OpenChannelModal: FC<Props> = ({ balance, onClose }) => {
             node_URI: data.nodeUri,
             target_confs: +data.feeRate,
           },
-        }
+        },
       )
       .then(() => {
         toast.success(t("home.channel_opened"), { theme });
@@ -72,62 +70,59 @@ const OpenChannelModal: FC<Props> = ({ balance, onClose }) => {
   const convertedBalance = balance ? convertMSatToSat(balance) : 0;
 
   return createPortal(
-    <ModalDialog close={onClose}>
-      <h2 className="text-lg font-bold">{t("home.open_channel")}</h2>
-      <article className="my-5">
+    <Modal
+      closeFunc={onClose}
+      submitFunc={handleSubmit(openChannelHandler)}
+      title={t("home.open_channel")}
+      submitLabel={t("home.open_channel")}
+      is-loading={isLoading}
+    >
+      <fieldset className="mb-5 sm:w-96">
         <AvailableBalance balance={convertedBalance!} />
 
-        <form onSubmit={handleSubmit(openChannelHandler)}>
-          <InputField
-            {...register("nodeUri", {
-              required: t("forms.validation.node_uri.required"),
-            })}
-            label={t("home.node_uri")}
-            errorMessage={errors.nodeUri}
-          />
-          <AmountInput
-            amount={amount}
-            errorMessage={errors.fundingAmount}
-            register={register("fundingAmount", {
-              required: t("forms.validation.amount.required"),
-              validate: {
-                greaterThanZero: (val) =>
-                  stringToNumber(val) > 0 ||
-                  t("forms.validation.amount.required"),
-              },
-              onChange: changeAmountHandler,
-            })}
-          />
-          <div className="flex justify-around py-8 md:mx-auto md:w-1/2">
-            <label htmlFor="targetConf" className="font-bold">
-              {t("tx.fee_rate")}
-            </label>
-            <select
-              id="targetConf"
-              defaultValue={4}
-              {...register("feeRate")}
-              className="rounded bg-yellow-500 p-1 text-white"
-            >
-              <option value={1}>{t("home.urgent")}</option>
-              <option value={4}>{t("home.normal")}</option>
-              <option value={20}>{t("home.slow")}</option>
-            </select>
-          </div>
+        <InputField
+          {...register("nodeUri", {
+            required: t("forms.validation.node_uri.required"),
+          })}
+          label={t("home.node_uri")}
+          errorMessage={errors.nodeUri}
+        />
 
-          <ButtonWithSpinner
-            type="submit"
-            className="bd-button p-2"
-            loading={isLoading}
-            disabled={!isValid}
-            icon={<LinkIcon className="mx-1 h-6 w-6" />}
+        <AmountInput
+          amount={amount}
+          errorMessage={errors.fundingAmount}
+          register={register("fundingAmount", {
+            required: t("forms.validation.amount.required"),
+            validate: {
+              greaterThanZero: (val) =>
+                stringToNumber(val) > 0 ||
+                t("forms.validation.amount.required"),
+            },
+            onChange: changeAmountHandler,
+          })}
+        />
+
+        <div>
+          <label htmlFor="targetConf" className="label-underline">
+            {t("tx.fee_rate")}
+          </label>
+
+          <select
+            id="targetConf"
+            defaultValue={4}
+            {...register("feeRate")}
+            className="p-2 rounded shadow-md dark:bg-gray-600"
           >
-            {t("home.open_channel")}
-          </ButtonWithSpinner>
-        </form>
+            <option value={1}>{t("home.urgent")}</option>
+            <option value={4}>{t("home.normal")}</option>
+            <option value={20}>{t("home.slow")}</option>
+          </select>
+        </div>
+
         {error && <Message message={error} />}
-      </article>
-    </ModalDialog>,
-    MODAL_ROOT
+      </fieldset>
+    </Modal>,
+    MODAL_ROOT,
   );
 };
 

--- a/src/pages/Home/ReceiveModal/ReceiveAddress.tsx
+++ b/src/pages/Home/ReceiveModal/ReceiveAddress.tsx
@@ -8,7 +8,7 @@ type Props = {
   address: string;
 };
 
-const ReceiveOnChain: FC<Props> = ({ address }) => {
+const ReceiveAddress: FC<Props> = ({ address }) => {
   const { t } = useTranslation();
   const [copyAddress, addressCopied] = useClipboard(address);
 
@@ -36,4 +36,4 @@ const ReceiveOnChain: FC<Props> = ({ address }) => {
   );
 };
 
-export default ReceiveOnChain;
+export default ReceiveAddress;

--- a/src/pages/Home/ReceiveModal/ReceiveModal.tsx
+++ b/src/pages/Home/ReceiveModal/ReceiveModal.tsx
@@ -10,7 +10,7 @@ import InputField from "../../../components/InputField";
 import LoadingSpinner from "../../../components/LoadingSpinner/LoadingSpinner";
 import Message from "../../../components/Message";
 import { AppContext, Unit } from "../../../context/app-context";
-import ModalDialog from "../../../layouts/ModalDialog";
+import Modal from "../../../layouts/Modal";
 import { MODAL_ROOT } from "../../../utils";
 import { checkError } from "../../../utils/checkError";
 import { convertBtcToSat, stringToNumber } from "../../../utils/format";
@@ -104,11 +104,11 @@ const ReceiveModal: FC<Props> = ({ onClose }) => {
     generateInvoiceHandler();
 
   return createPortal(
-    <ModalDialog close={onClose}>
-      <div className="text-xl font-bold">
-        {showLnInvoice ? t("wallet.create_invoice_ln") : t("wallet.fund")}
-      </div>
-
+    <Modal
+      close={onClose}
+      showFooter={!address}
+      title={showLnInvoice ? t("wallet.create_invoice_ln") : t("wallet.fund")}
+    >
       <div className="my-3">
         <SwitchTxType
           invoiceType={invoiceType}
@@ -174,7 +174,7 @@ const ReceiveModal: FC<Props> = ({ onClose }) => {
       </form>
 
       {address && <ReceiveOnChain address={address} />}
-    </ModalDialog>,
+    </Modal>,
     MODAL_ROOT
   );
 };

--- a/src/pages/Home/ReceiveModal/ReceiveModal.tsx
+++ b/src/pages/Home/ReceiveModal/ReceiveModal.tsx
@@ -94,7 +94,7 @@ const ReceiveModal: FC<Props> = ({ onClose }) => {
   const {
     register,
     handleSubmit,
-    formState: { errors, isValid, submitCount },
+    formState: { errors },
   } = useForm<IFormInputs>({
     mode: "onChange",
   });
@@ -121,10 +121,6 @@ const ReceiveModal: FC<Props> = ({ onClose }) => {
         />
       </div>
 
-      {/* <form
-        className="flex w-full flex-col items-center"
-        onSubmit={handleSubmit(onSubmit)}
-      > */}
       <fieldset className="mb-5 sm:w-96">
         {isLoading && (
           <div className="p-5">
@@ -162,22 +158,7 @@ const ReceiveModal: FC<Props> = ({ onClose }) => {
         )}
 
         {error && <Message message={error} />}
-
-        {/* {showLnInvoice && !address && (
-          <div className="flex items-center justify-center">
-            <button
-              type="submit"
-              className="bd-button my-3 flex items-center justify-center p-3"
-              disabled={submitCount > 0 && !isValid}
-            >
-              <PlusCircleIcon className="mr-1 inline h-6 w-6" />
-              <span>{t("wallet.create_invoice")}</span>
-            </button>
-          </div>
-        )} */}
       </fieldset>
-
-      {/* </form> */}
 
       {address && <ReceiveAddress address={address} />}
     </Modal>,

--- a/src/pages/Home/ReceiveModal/ReceiveModal.tsx
+++ b/src/pages/Home/ReceiveModal/ReceiveModal.tsx
@@ -120,7 +120,7 @@ const ReceiveModal: FC<Props> = ({ onClose }) => {
         className="flex w-full flex-col items-center"
         onSubmit={handleSubmit(onSubmit)}
       >
-        <fieldset className="mb-5 w-4/5">
+        <fieldset className="mb-5 sm:w-96">
           {isLoading && (
             <div className="p-5">
               <LoadingSpinner />
@@ -158,7 +158,7 @@ const ReceiveModal: FC<Props> = ({ onClose }) => {
 
           {error && <Message message={error} />}
 
-          {!address && showLnInvoice && (
+          {showLnInvoice && !address && (
             <div className="flex items-center justify-center">
               <button
                 type="submit"

--- a/src/pages/Home/ReceiveModal/ReceiveModal.tsx
+++ b/src/pages/Home/ReceiveModal/ReceiveModal.tsx
@@ -110,7 +110,7 @@ const ReceiveModal: FC<Props> = ({ onClose }) => {
       submitFunc={handleSubmit(onSubmit)}
       backFunc={address && lnInvoice ? onBack : undefined}
       title={showLnInvoice ? t("wallet.create_invoice_ln") : t("wallet.fund")}
-      submitTitle={
+      submitLabel={
         showLnInvoice && !address ? t("wallet.create_invoice") : undefined
       }
     >

--- a/src/pages/Home/ReceiveModal/ReceiveModal.tsx
+++ b/src/pages/Home/ReceiveModal/ReceiveModal.tsx
@@ -1,4 +1,3 @@
-import { PlusCircleIcon } from "@heroicons/react/24/outline";
 import type { ChangeEvent, FC } from "react";
 import { useContext, useState } from "react";
 import { createPortal } from "react-dom";
@@ -16,7 +15,7 @@ import { checkError } from "../../../utils/checkError";
 import { convertBtcToSat, stringToNumber } from "../../../utils/format";
 import { instance } from "../../../utils/interceptor";
 import SwitchTxType, { TxType } from "../SwitchTxType";
-import ReceiveOnChain from "./ReceiveOnChain";
+import ReceiveAddress from "./ReceiveAddress";
 
 interface IFormInputs {
   amountInput: string;
@@ -103,11 +102,17 @@ const ReceiveModal: FC<Props> = ({ onClose }) => {
   const onSubmit: SubmitHandler<IFormInputs> = (_data) =>
     generateInvoiceHandler();
 
+  const onBack = () => setAddress("");
+
   return createPortal(
     <Modal
-      close={onClose}
-      showFooter={!address}
+      closeFunc={onClose(false)}
+      submitFunc={handleSubmit(onSubmit)}
+      backFunc={address && lnInvoice ? onBack : undefined}
       title={showLnInvoice ? t("wallet.create_invoice_ln") : t("wallet.fund")}
+      submitTitle={
+        showLnInvoice && !address ? t("wallet.create_invoice") : undefined
+      }
     >
       <div className="my-3">
         <SwitchTxType
@@ -116,66 +121,67 @@ const ReceiveModal: FC<Props> = ({ onClose }) => {
         />
       </div>
 
-      <form
+      {/* <form
         className="flex w-full flex-col items-center"
         onSubmit={handleSubmit(onSubmit)}
-      >
-        <fieldset className="mb-5 sm:w-96">
-          {isLoading && (
-            <div className="p-5">
-              <LoadingSpinner />
-            </div>
-          )}
+      > */}
+      <fieldset className="mb-5 sm:w-96">
+        {isLoading && (
+          <div className="p-5">
+            <LoadingSpinner />
+          </div>
+        )}
 
-          {showLnInvoice && !address && (
-            <div className="flex flex-col justify-center pb-5 text-center">
-              <AmountInput
-                amount={amount}
-                register={register("amountInput", {
-                  required: t("forms.validation.chainAmount.required"),
-                  validate: {
-                    greaterThanZero: (val) =>
-                      stringToNumber(val) > 0 ||
-                      t("forms.validation.chainAmount.required"),
-                  },
-                  onChange: amountChangeHandler,
+        {showLnInvoice && !address && (
+          <div className="flex flex-col justify-center pb-5 text-center">
+            <AmountInput
+              amount={amount}
+              register={register("amountInput", {
+                required: t("forms.validation.chainAmount.required"),
+                validate: {
+                  greaterThanZero: (val) =>
+                    stringToNumber(val) > 0 ||
+                    t("forms.validation.chainAmount.required"),
+                },
+                onChange: amountChangeHandler,
+              })}
+              errorMessage={errors.amountInput}
+            />
+
+            <div className="mt-2 flex flex-col justify-center">
+              <InputField
+                {...register("commentInput", {
+                  onChange: commentChangeHandler,
                 })}
-                errorMessage={errors.amountInput}
+                label={t("tx.comment")}
+                value={comment}
+                placeholder={t("tx.comment_placeholder")}
               />
-
-              <div className="mt-2 flex flex-col justify-center">
-                <InputField
-                  {...register("commentInput", {
-                    onChange: commentChangeHandler,
-                  })}
-                  label={t("tx.comment")}
-                  value={comment}
-                  placeholder={t("tx.comment_placeholder")}
-                />
-              </div>
             </div>
-          )}
+          </div>
+        )}
 
-          {error && <Message message={error} />}
+        {error && <Message message={error} />}
 
-          {showLnInvoice && !address && (
-            <div className="flex items-center justify-center">
-              <button
-                type="submit"
-                className="bd-button my-3 flex items-center justify-center p-3"
-                disabled={submitCount > 0 && !isValid}
-              >
-                <PlusCircleIcon className="mr-1 inline h-6 w-6" />
-                <span>{t("wallet.create_invoice")}</span>
-              </button>
-            </div>
-          )}
-        </fieldset>
-      </form>
+        {/* {showLnInvoice && !address && (
+          <div className="flex items-center justify-center">
+            <button
+              type="submit"
+              className="bd-button my-3 flex items-center justify-center p-3"
+              disabled={submitCount > 0 && !isValid}
+            >
+              <PlusCircleIcon className="mr-1 inline h-6 w-6" />
+              <span>{t("wallet.create_invoice")}</span>
+            </button>
+          </div>
+        )} */}
+      </fieldset>
 
-      {address && <ReceiveOnChain address={address} />}
+      {/* </form> */}
+
+      {address && <ReceiveAddress address={address} />}
     </Modal>,
-    MODAL_ROOT
+    MODAL_ROOT,
   );
 };
 

--- a/src/pages/Home/ReceiveModal/ReceiveModal.tsx
+++ b/src/pages/Home/ReceiveModal/ReceiveModal.tsx
@@ -106,7 +106,7 @@ const ReceiveModal: FC<Props> = ({ onClose }) => {
 
   return createPortal(
     <Modal
-      closeFunc={onClose(false)}
+      closeFunc={onClose}
       submitFunc={handleSubmit(onSubmit)}
       backFunc={address && lnInvoice ? onBack : undefined}
       title={showLnInvoice ? t("wallet.create_invoice_ln") : t("wallet.fund")}

--- a/src/pages/Home/SwitchTxType.tsx
+++ b/src/pages/Home/SwitchTxType.tsx
@@ -26,6 +26,7 @@ const SwitchTxType: FC<Props> = ({ invoiceType, onTxTypeChange, disabled }) => {
   return (
     <div className="my-3">
       <button
+        type="button"
         name="lightning"
         disabled={invoiceType === TxType.LIGHTNING}
         className="switch-button"
@@ -36,6 +37,7 @@ const SwitchTxType: FC<Props> = ({ invoiceType, onTxTypeChange, disabled }) => {
       </button>
 
       <button
+        type="button"
         name="onchain"
         disabled={invoiceType === TxType.ONCHAIN}
         className="switch-button"

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -156,6 +156,7 @@ const Home: FC = () => {
   const closeModalHandler = (txSent?: boolean) => {
     setShowModal(false);
     setDetailTx(null);
+
     if (txSent) {
       toast.success(t("tx.sent"), { theme });
     }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,8 +9,8 @@ module.exports = {
         "bd-yellow-dark": "#F7CB47",
       },
     },
-    maxWidth: {
-      "4/5": "80%",
-    },
+    // maxWidth: {
+    //   "4/5": "80%",
+    // },
   },
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,8 +9,5 @@ module.exports = {
         "bd-yellow-dark": "#F7CB47",
       },
     },
-    // maxWidth: {
-    //   "4/5": "80%",
-    // },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1863,6 +1863,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@headlessui/react@npm:^1.7.15":
+  version: 1.7.16
+  resolution: "@headlessui/react@npm:1.7.16"
+  dependencies:
+    client-only: ^0.0.1
+  peerDependencies:
+    react: ^16 || ^17 || ^18
+    react-dom: ^16 || ^17 || ^18
+  checksum: 85844c96c79796236fa7dec2f1c2f0332d7554d9b785d7b37d9762bb4133088a0cf1334653d6f91c1fe4619960eb569f14ba5f6a962c3305e03f7b362acbabbe
+  languageName: node
+  linkType: hard
+
 "@heroicons/react@npm:^2.0.18":
   version: 2.0.18
   resolution: "@heroicons/react@npm:2.0.18"
@@ -3521,6 +3533,13 @@ __metadata:
   version: 3.0.0
   resolution: "cli-width@npm:3.0.0"
   checksum: 4c94af3769367a70e11ed69aa6095f1c600c0ff510f3921ab4045af961820d57c0233acfa8b6396037391f31b4c397e1f614d234294f979ff61430a6c166c3f6
+  languageName: node
+  linkType: hard
+
+"client-only@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "client-only@npm:0.0.1"
+  checksum: 0c16bf660dadb90610553c1d8946a7fdfb81d624adea073b8440b7d795d5b5b08beb3c950c6a2cf16279365a3265158a236876d92bce16423c485c322d7dfaf8
   languageName: node
   linkType: hard
 
@@ -7037,6 +7056,7 @@ __metadata:
   resolution: "raspiblitz-web@workspace:."
   dependencies:
     "@bitcoin-design/bitcoin-icons-react": ^0.1.9
+    "@headlessui/react": ^1.7.15
     "@heroicons/react": ^2.0.18
     "@testing-library/dom": ^9.3.1
     "@testing-library/jest-dom": ^5.17.0


### PR DESCRIPTION
Fixes #413 

# First draft

Only took care of the receive modal for now to test this.  
Happy for any feedback.

## Screenshots
<img width="530" alt="image" src="https://github.com/raspiblitz/raspiblitz-web/assets/1016218/63be7bf4-1440-40eb-9797-1d2e8d765d1f">

<img width="531" alt="image" src="https://github.com/raspiblitz/raspiblitz-web/assets/1016218/c2568cc6-d425-45d4-95f4-fa5aa2c3fa89">

<img width="537" alt="image" src="https://github.com/raspiblitz/raspiblitz-web/assets/1016218/b368d27d-3903-46df-ae79-b994d770d00d">


## Open points

- modal needs to be checked for all screen-sizes 
- light-mode looks weird, but it kinda looks weird on `master` too
- buttons could be optimized in general i.e.
   - go with 3 versions: primary, secondary, default
   - they all work in light- and dark-mode
   - should handle different states (i.e. disabled) and icons (i.e. spinner)
   - should be done in another PR
- switch tab-component to headlessui as well (new PR)