### PR TITLE
feat: add refresh address button for qr code

### DIFF
--- a/src/i18n/langs/cs.json
+++ b/src/i18n/langs/cs.json
@@ -300,6 +300,7 @@
       "invoice": "Faktura",
       "on_chain": "On-chain",
       "receive": "Přijmout",
+      "refresh": "Obnovit adresu",
       "scan_qr": "Naskenujte tento QR kód nebo zkopírujte níže uvedenou adresu pro zaslání finančních prostředků",
       "send": "Odeslat",
       "send_lightning": "Odeslat prostředky přes Lightning",

--- a/src/i18n/langs/de.json
+++ b/src/i18n/langs/de.json
@@ -332,6 +332,7 @@
       "invoice": "Rechnung",
       "on_chain": "On-chain",
       "receive": "Erhalten",
+      "refresh": "Adresse aktualisieren",
       "scan_qr": "Scannen Sie diesen QR-Code oder kopieren Sie die unten stehende Adresse, um das Geld zu erhalten",
       "send": "Senden",
       "send_lightning": "Geld via Lightning versenden",

--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -341,6 +341,7 @@
       "invoice": "Invoice",
       "on_chain": "On-chain",
       "receive": "Receive",
+      "refresh": "Refresh address",
       "scan_qr": "Scan this QR code or copy the address below to receive funds",
       "send": "Send",
       "send_lightning": "Send funds over Lightning",

--- a/src/i18n/langs/es.json
+++ b/src/i18n/langs/es.json
@@ -284,6 +284,7 @@
       "invoice": "Factura",
       "on_chain": "On-chain",
       "receive": "Recibir",
+      "refresh": "Actualizar dirección",
       "scan_qr": "Escánea este código QR o copia la dirección de abajo para solicitar los fondos",
       "send": "Enviar",
       "send_lightning": "Envía fondos vía Lightning",

--- a/src/i18n/langs/fr.json
+++ b/src/i18n/langs/fr.json
@@ -315,6 +315,7 @@
       "invoice": "Facture",
       "on_chain": "On-chain",
       "receive": "Recevoir",
+      "refresh": "Actualiser l'adresse",
       "scan_qr": "Scannez ce code QR ou copiez l'adresse ci-dessous pour recevoir des fonds",
       "send": "Envoyer",
       "send_lightning": "Envoyer de l'argent avec Lightning",

--- a/src/i18n/langs/hu.json
+++ b/src/i18n/langs/hu.json
@@ -92,6 +92,7 @@
       "fund": "Töltse fel a tárcáját",
       "on_chain": "Láncon",
       "receive": "Fogadás",
+      "refresh": "Cím frissítése",
       "scan_qr": "Szkennelje be ezt a QR kódot, vagy másolja ki a fizetési címet hogy pénzt fogadhasson",
       "send": "Küldés"
     }

--- a/src/i18n/langs/it.json
+++ b/src/i18n/langs/it.json
@@ -97,6 +97,7 @@
       "invoice": "Invoice",
       "on_chain": "On-chain",
       "receive": "Ricevi",
+      "refresh": "Aggiorna indirizzo",
       "scan_qr": "Scannerizza questo codice QR o copia l'indirizzo sottostante per ricevere denaro",
       "send": "Invia",
       "send_lightning": "Invia denaro via Lightning",

--- a/src/i18n/langs/nb_NO.json
+++ b/src/i18n/langs/nb_NO.json
@@ -170,6 +170,7 @@
       "invoice": "Faktura",
       "on_chain": "On-chain",
       "receive": "Motta",
+      "refresh": "Oppdater adresse",
       "scan_qr": "Skann denne QR-koden eller kopier adressen nedenfor for å motta midler",
       "send": "Send",
       "send_lightning": "Send midler over Lyn",

--- a/src/i18n/langs/nl.json
+++ b/src/i18n/langs/nl.json
@@ -313,6 +313,7 @@
       "invoice": "Rekening",
       "on_chain": "On-chain",
       "receive": "Ontvang",
+      "refresh": "Adres vernieuwen",
       "scan_qr": "Scan deze QR code of kopieer onderstaand adres om tegoeden te ontvangen",
       "send": "Stuur",
       "send_lightning": "Stuur tegoeden via Lightning",

--- a/src/i18n/langs/pt.json
+++ b/src/i18n/langs/pt.json
@@ -315,6 +315,7 @@
       "invoice": "Fatura",
       "on_chain": "On-chain",
       "receive": "Receber",
+      "refresh": "Atualizar endereço",
       "scan_qr": "Leia este código QR ou copie o endereço abaixo para receber fundos",
       "send": "Enviar",
       "send_lightning": "Enviar fundos via Lightning",

--- a/src/i18n/langs/pt_BR.json
+++ b/src/i18n/langs/pt_BR.json
@@ -300,6 +300,7 @@
       "invoice": "Fatura",
       "on_chain": "On-chain",
       "receive": "Receber",
+      "refresh": "Atualizar endereço",
       "scan_qr": "Leia este código QR ou copie o endereço abaixo para receber fundos",
       "send": "Enviar",
       "send_lightning": "Enviar fundos via Lightning",

--- a/src/i18n/langs/sv.json
+++ b/src/i18n/langs/sv.json
@@ -300,6 +300,7 @@
       "invoice": "Faktura",
       "on_chain": "On-chain",
       "receive": "Mottag",
+      "refresh": "Uppdatera adress",
       "scan_qr": "Scanna QR-koden eller kopiera adressen nedan för att ta emot medel",
       "send": "Skicka",
       "send_lightning": "Skicka medel över Lightning",

--- a/src/i18n/langs/vi.json
+++ b/src/i18n/langs/vi.json
@@ -300,6 +300,7 @@
       "invoice": "Hóa đơn",
       "on_chain": "Trên chuỗi khối",
       "receive": "Nhận",
+      "refresh": "Làm mới địa chỉ",
       "scan_qr": "Quét mã QR hoặc sao chép địa chỉ bên dưới để nhận vốn",
       "send": "Gửi",
       "send_lightning": "Gửi vốn qua Lightning",

--- a/src/layouts/ModalDialog.tsx
+++ b/src/layouts/ModalDialog.tsx
@@ -43,7 +43,7 @@ const ModalDialog: FC<PropsWithChildren<Props>> = ({
 
   return (
     <ModalBackground>
-      <div className="xl:max-w-screen-sm flex h-screen max-h-full w-screen flex-col overflow-y-auto rounded-lg bg-white pb-4 text-center shadow-xl dark:bg-gray-800 dark:text-white md:h-auto md:w-4/5 lg:w-1/2 xl:mx-5 xl:w-2/5">
+      <div className="xl:max-w-screen-sm flex h-screen max-h-full w-screen flex-col overflow-y-auto rounded-lg bg-white pb-8 text-center shadow-xl dark:bg-gray-800 dark:text-white md:h-auto md:w-4/5 lg:w-1/2 xl:mx-5 xl:w-2/5">
         <div className="flex pr-2 pt-1">
           <button
             onClick={closeModal}

--- a/src/pages/Home/ReceiveModal/ReceiveModal.tsx
+++ b/src/pages/Home/ReceiveModal/ReceiveModal.tsx
@@ -173,7 +173,14 @@ const ReceiveModal: FC<Props> = ({ onClose }) => {
         </fieldset>
       </form>
 
-      {address && <ReceiveOnChain address={address} />}
+      {address && (
+        <ReceiveOnChain
+          address={address}
+          setAddress={setAddress}
+          setIsLoading={setIsLoading}
+          setError={setError}
+        />
+      )}
     </ModalDialog>,
     MODAL_ROOT,
   );

--- a/src/pages/Home/ReceiveModal/ReceiveOnChain.tsx
+++ b/src/pages/Home/ReceiveModal/ReceiveOnChain.tsx
@@ -1,16 +1,45 @@
 import { QRCodeSVG } from "qrcode.react";
 import { Tooltip } from "react-tooltip";
-import { FC } from "react";
+import { Dispatch, FC, SetStateAction } from "react";
 import { useTranslation } from "react-i18next";
 import useClipboard from "@/hooks/use-clipboard";
+import { instance } from "@/utils/interceptor";
+import { RefreshIcon } from "@bitcoin-design/bitcoin-icons-react/filled";
+import { ApiError, checkError } from "@/utils/checkError";
+import { AxiosError } from "axios";
 
 type Props = {
   address: string;
+  setAddress: Dispatch<SetStateAction<string>>;
+  setIsLoading: Dispatch<SetStateAction<boolean>>;
+  setError: Dispatch<SetStateAction<string>>;
 };
 
-const ReceiveOnChain: FC<Props> = ({ address }) => {
+const ReceiveOnChain: FC<Props> = ({
+  address,
+  setAddress,
+  setIsLoading,
+  setError,
+}) => {
   const { t } = useTranslation();
   const [copyAddress, addressCopied] = useClipboard(address);
+
+  const refreshAddressHandler = async () => {
+    setAddress("");
+    setError("");
+
+    try {
+      setIsLoading(true);
+      const response = await instance.post("lightning/new-address", {
+        type: "p2wkh",
+      });
+      setAddress(response.data);
+    } catch (error) {
+      setError(checkError(error as AxiosError<ApiError>));
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   return (
     <>
@@ -32,6 +61,18 @@ const ReceiveOnChain: FC<Props> = ({ address }) => {
           </div>
         </Tooltip>
       </article>
+      <div>
+        <button
+          name="refresh-address"
+          className="switch-button"
+          onClick={refreshAddressHandler}
+        >
+          <span className="flex">
+            <RefreshIcon className="mr-1 h-6 w-6" />
+            {t("wallet.refresh")}
+          </span>
+        </button>
+      </div>
     </>
   );
 };

--- a/src/pages/Home/ReceiveModal/__tests__/ReceiveModal.test.tsx
+++ b/src/pages/Home/ReceiveModal/__tests__/ReceiveModal.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "test-utils";
 import { http, server, HttpResponse } from "@/testServer";
 import ReceiveModal from "../ReceiveModal";
 
-beforeAll(() => {
+beforeEach(() => {
   server.use(
     http.post("/api/lightning/new-address", () => {
       return new HttpResponse("bcrt1qvh74klc36lefsdgq5r2d44vwxxzkdsch0hhyrz", {
@@ -23,5 +23,36 @@ describe("ReceiveModal", () => {
     await user.click(onChainBtn);
 
     expect(await screen.findByRole("img")).toBeDefined();
+  });
+
+  test("Retrieves a new address upon clicking the refresh button", async () => {
+    const user = userEvent.setup();
+    render(<ReceiveModal onClose={() => {}} />);
+
+    const onChainBtn = screen.getByRole("button", { name: "wallet.on_chain" });
+
+    await user.click(onChainBtn);
+
+    // one-time address override
+    const newMockAddress = "muZ3nH1uH2U5JBhZRvYU46MdChbCifSghQ";
+    server.use(
+      http.post(
+        "/api/lightning/new-address",
+        () => {
+          return new HttpResponse(newMockAddress, {
+            status: 200,
+          });
+        },
+        { once: true },
+      ),
+    );
+
+    const refreshBtn = await screen.findByRole("button", {
+      name: "wallet.refresh",
+    });
+    await user.click(refreshBtn);
+
+    expect(await screen.findByRole("img")).toBeInTheDocument();
+    expect(await screen.findByText(newMockAddress)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION

# Description

This PR addresses issue #431 

- Add Refresh Address button to receive on-chain dialog
- Add loading and error handling during refresh (using previously exisiting SetStateAction functions)
- Add related unit tests
- Add translations (to the best of my ability, happy to remove if this is not needed)

## Screen Recording

This is a short demo of the resulting behaviour (with an overridden response, given that the mock backend seems to return the same address from the `new-address` endpoint).

![refresh_address](https://github.com/raspiblitz/raspiblitz-web/assets/9814036/6fc2df95-5381-46a4-9958-bce1d04ac707)
