### PR TITLE
feat: add caps-lock hook and warning

### DIFF
--- a/src/components/CapsLockWarning.tsx
+++ b/src/components/CapsLockWarning.tsx
@@ -1,0 +1,14 @@
+import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import { useTranslation } from "react-i18next";
+
+const CapsLockWarning = () => {
+  const { t } = useTranslation();
+  return (
+    <p className="flex items-center gap-1 text-yellow-500">
+      <ExclamationTriangleIcon className="size-4" />
+      {t("login.caps_lock")}
+    </p>
+  );
+};
+
+export default CapsLockWarning;

--- a/src/hooks/use-caps-lock.ts
+++ b/src/hooks/use-caps-lock.ts
@@ -1,0 +1,29 @@
+import { KeyboardEvent, useState } from "react";
+
+const useCapsLock = () => {
+  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
+
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.getModifierState("CapsLock")) {
+      setIsCapsLockOn(true);
+    }
+  };
+
+  const onKeyUp = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (isCapsLockOn) {
+      if (!event.getModifierState("CapsLock")) {
+        setIsCapsLockOn(false);
+      }
+    }
+  };
+
+  return {
+    isCapsLockOn,
+    keyHandlers: {
+      onKeyDown,
+      onKeyUp,
+    },
+  };
+};
+
+export default useCapsLock;

--- a/src/i18n/langs/cs.json
+++ b/src/i18n/langs/cs.json
@@ -160,7 +160,8 @@
       "enter_pass_placeholder": "Heslo A",
       "error": "Došlo k chybě",
       "invalid_pass": "Neplatné heslo",
-      "login": "Přihlášení"
+      "login": "Přihlášení",
+      "caps_lock": "El Bloq Majús està ACTIVAT"
     },
     "navigation": {
       "apps": "Aplikace",

--- a/src/i18n/langs/de.json
+++ b/src/i18n/langs/de.json
@@ -182,6 +182,7 @@
       "error": "Es ist ein Fehler aufgetreten",
       "invalid_pass": "Ungültiges Passwort",
       "login": "Anmelden",
+      "caps_lock": "Die Feststelltaste ist AKTIVIERT",
       "unknown_error": "Unbekannter Fehler. Die Antwort war: {{code}} {{statusText}}."
     },
     "navigation": {

--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -190,7 +190,8 @@
       "error": "An error occurred",
       "unknown_error": "Unknown error. The response was: {{code}} {{statusText}}.",
       "invalid_pass": "Invalid password",
-      "login": "Log in"
+      "login": "Log in",
+      "caps_lock": "Caps Lock is ON"
     },
     "navigation": {
       "apps": "Apps",

--- a/src/i18n/langs/es.json
+++ b/src/i18n/langs/es.json
@@ -134,6 +134,7 @@
       "error": "Se ha producido un error",
       "invalid_pass": "Contraseña Inválida",
       "login": "Iniciar Sesión",
+      "caps_lock": "El Bloqueo de Mayúsculas está ACTIVADO",
       "unknown_error": "Error desconocido. La respuesta fue: {{code}} {{statusText}}."
     },
     "navigation": {

--- a/src/i18n/langs/fr.json
+++ b/src/i18n/langs/fr.json
@@ -168,6 +168,7 @@
       "error": "Une erreur s'est produite",
       "invalid_pass": "Mot de passe invalide",
       "login": "Se connecter",
+      "caps_lock": "Le Verrouillage des Majuscules est ACTIVÉ",
       "unknown_error": "Erreur inconnue. La réponse était : {{code}} {{statusText}}."
     },
     "navigation": {

--- a/src/i18n/langs/hu.json
+++ b/src/i18n/langs/hu.json
@@ -46,7 +46,8 @@
       "enter_pass_placeholder": "Jelszó A",
       "error": "Hiba történt",
       "invalid_pass": "Helytelen jelszó",
-      "login": "Bejelentkezés"
+      "login": "Bejelentkezés",
+      "caps_lock": "A Caps Lock BE van kapcsolva"
     },
     "navigation": {
       "apps": "Appok",

--- a/src/i18n/langs/it.json
+++ b/src/i18n/langs/it.json
@@ -46,7 +46,8 @@
       "enter_pass_placeholder": "Password A",
       "error": "C'è stato un errore",
       "invalid_pass": "Password non valida",
-      "login": "Log in"
+      "login": "Log in",
+      "caps_lock": "Il Blocco Maiuscole è ATTIVO"
     },
     "navigation": {
       "apps": "Applicazioni",

--- a/src/i18n/langs/nb_NO.json
+++ b/src/i18n/langs/nb_NO.json
@@ -116,7 +116,8 @@
       "enter_pass_placeholder": "Passord A",
       "error": "En feil inntraff",
       "invalid_pass": "Ugyldig passord",
-      "login": "Logg inn"
+      "login": "Logg inn",
+      "caps_lock": "Caps Lock er PÅ"
     },
     "navigation": {
       "apps": "Programmer",

--- a/src/i18n/langs/nl.json
+++ b/src/i18n/langs/nl.json
@@ -168,6 +168,7 @@
       "error": "Er is een fout opgetreden",
       "invalid_pass": "Ongeldig wachtwoord",
       "login": "Inloggen",
+      "caps_lock": "Caps Lock staat AAN",
       "unknown_error": "Onbekende fout. De reactie was: {{code}} {{statusText}}."
     },
     "navigation": {

--- a/src/i18n/langs/pt.json
+++ b/src/i18n/langs/pt.json
@@ -188,6 +188,7 @@
       "enter_pass_placeholder": "Palavra-passe A",
       "invalid_pass": "Palavra-passe inválida",
       "login": "Acessar",
+      "caps_lock": "O Caps Lock está ATIVO",
       "error": "Ocorreu um erro",
       "unknown_error": "Erro desconhecido. A resposta foi: {{code}} {{statusText}}."
     },

--- a/src/i18n/langs/pt_BR.json
+++ b/src/i18n/langs/pt_BR.json
@@ -160,7 +160,8 @@
       "enter_pass_placeholder": "Senha A",
       "error": "Ocorreu um erro",
       "invalid_pass": "Senha inválida",
-      "login": "Acessar"
+      "login": "Acessar",
+      "caps_lock": "O Caps Lock está ATIVADO"
     },
     "navigation": {
       "apps": "Aplicativos",

--- a/src/i18n/langs/sv.json
+++ b/src/i18n/langs/sv.json
@@ -160,7 +160,8 @@
       "enter_pass_placeholder": "Lösenord A",
       "error": "Ett fel inträffade",
       "invalid_pass": "Ogiltigt lösenord",
-      "login": "Logga in"
+      "login": "Logga in",
+      "caps_lock": "Caps Lock är PÅSLAGET"
     },
     "navigation": {
       "apps": "Appar",

--- a/src/i18n/langs/vi.json
+++ b/src/i18n/langs/vi.json
@@ -160,7 +160,8 @@
       "enter_pass_placeholder": "Mật khẩu A",
       "error": "Báo lỗi",
       "invalid_pass": "Sai mật khẩu",
-      "login": "Đăng nhập"
+      "login": "Đăng nhập",
+      "caps_lock": "Caps Lock đang BẬT"
     },
     "navigation": {
       "apps": "Ứng dụng",

--- a/src/pages/Home/UnlockModal.tsx
+++ b/src/pages/Home/UnlockModal.tsx
@@ -12,6 +12,8 @@ import { AppContext } from "@/context/app-context";
 import ModalDialog, { disableScroll } from "@/layouts/ModalDialog";
 import { MODAL_ROOT } from "@/utils";
 import { instance } from "@/utils/interceptor";
+import useCapsLock from "@/hooks/use-caps-lock";
+import CapsLockWarning from "@/components/CapsLockWarning";
 
 interface IFormInputs {
   passwordInput: string;
@@ -26,6 +28,7 @@ const UnlockModal: FC<Props> = ({ onClose }) => {
   const { setWalletLocked, darkMode } = useContext(AppContext);
   const [isLoading, setIsLoading] = useState(false);
   const [passwordWrong, setPasswordWrong] = useState(false);
+  const { isCapsLockOn, keyHandlers } = useCapsLock();
   const theme = darkMode ? "dark" : "light";
 
   const {
@@ -76,7 +79,9 @@ const UnlockModal: FC<Props> = ({ onClose }) => {
             placeholder={t("forms.validation.unlock.pass_c")}
             type="password"
             disabled={isLoading}
+            {...keyHandlers}
           />
+          {isCapsLockOn && <CapsLockWarning />}
           <ButtonWithSpinner
             type="submit"
             className="bd-button my-5 p-3"

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,9 +1,11 @@
 import RaspiBlitzLogo from "@/assets/RaspiBlitz_Logo_Main.svg?react";
 import RaspiBlitzLogoDark from "@/assets/RaspiBlitz_Logo_Main_Negative.svg?react";
+import CapsLockWarning from "@/components/CapsLockWarning";
 import I18nDropdown from "@/components/I18nDropdown";
 import LoadingSpinner from "@/components/LoadingSpinner/LoadingSpinner";
 import Message from "@/components/Message";
 import { AppContext } from "@/context/app-context";
+import useCapsLock from "@/hooks/use-caps-lock";
 import { ACCESS_TOKEN, enableGutter } from "@/utils";
 import { ApiError, checkError } from "@/utils/checkError";
 import { instance } from "@/utils/interceptor";
@@ -24,6 +26,7 @@ const Login: FC = () => {
     useContext(AppContext);
   const navigate = useNavigate();
   const passwordInput = useRef<HTMLInputElement>(null);
+  const { isCapsLockOn, keyHandlers } = useCapsLock();
 
   const location = useLocation();
   const from =
@@ -108,7 +111,9 @@ const Login: FC = () => {
               placeholder={t("login.enter_pass_placeholder")}
               ref={passwordInput}
               type="password"
+              {...keyHandlers}
             />
+            {isCapsLockOn && <CapsLockWarning />}
             <button
               type="submit"
               className="m-4 flex items-center justify-center rounded bg-yellow-500 px-4 py-2 text-white hover:bg-yellow-400"

--- a/src/pages/Settings/ChangePwModal.tsx
+++ b/src/pages/Settings/ChangePwModal.tsx
@@ -10,6 +10,8 @@ import ModalDialog from "@/layouts/ModalDialog";
 import { MODAL_ROOT } from "@/utils";
 import { checkError } from "@/utils/checkError";
 import { instance } from "@/utils/interceptor";
+import useCapsLock from "@/hooks/use-caps-lock";
+import CapsLockWarning from "@/components/CapsLockWarning";
 
 export type Props = {
   onClose: () => void;
@@ -24,6 +26,7 @@ const ChangePwModal: FC<Props> = ({ onClose }) => {
   const [oldPassword, setOldPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const { isCapsLockOn, keyHandlers } = useCapsLock();
 
   const changePwHandler = () => {
     setIsLoading(true);
@@ -87,6 +90,7 @@ const ChangePwModal: FC<Props> = ({ onClose }) => {
             value={oldPassword}
             label={t("settings.old_pw")}
             errorMessage={errors.oldPassword}
+            {...keyHandlers}
           />
         </article>
         <article className="w-full py-2 md:w-10/12">
@@ -107,7 +111,9 @@ const ChangePwModal: FC<Props> = ({ onClose }) => {
             value={newPassword}
             label={t("settings.new_pw")}
             errorMessage={errors.newPassword}
+            {...keyHandlers}
           />
+          {isCapsLockOn && <CapsLockWarning />}
         </article>
         <article className="flex w-full flex-col justify-around gap-6 pt-8 text-white md:w-2/3 xl:flex-row">
           <button


### PR DESCRIPTION
# Description

This PR addresses #466 

- Add caps lock detection via `useCapsLock` hook
- Add `CapsLockWarning` component for user feedback
- Integrate with password A, password C, and change password inputs. Important to note, hooked up both inputs to the same warning to avoid having to handle caps lock detection independently, and to avoid weird duplicate or out-of-sync warnings.
- Add translations

## Screen Recordings

Password A
![2024-03-13_14-46-03 (1)](https://github.com/raspiblitz/raspiblitz-web/assets/9814036/993ffeb8-0a93-4583-9b0b-708dfd084970)

Password C
![2024-03-13_14-47-53 (1)](https://github.com/raspiblitz/raspiblitz-web/assets/9814036/2838d3d6-81be-4379-82f0-f1f6171fc8a0)

Change Password A (Settings)
![2024-03-13_14-50-59 (1)](https://github.com/raspiblitz/raspiblitz-web/assets/9814036/88b93052-bf23-45b2-ba83-ee103fb631a4)

