### PR TITLE
fix(setup): handle set and unset seedwords

### DIFF
--- a/src/pages/Setup/FinalDialog.tsx
+++ b/src/pages/Setup/FinalDialog.tsx
@@ -21,8 +21,7 @@ interface IFormInputs {
 
 const FinalDialog: FC<Props> = ({ setupPhase, seedWords, callback }) => {
   const { t } = useTranslation();
-  const words = seedWords.split(", ");
-  const isSetupRecovery = setupPhase === SetupPhase.RECOVERY;
+  const words = seedWords?.split(", ");
 
   const {
     handleSubmit,
@@ -58,7 +57,7 @@ const FinalDialog: FC<Props> = ({ setupPhase, seedWords, callback }) => {
             </ol>
           )}
 
-          {!isSetupRecovery && (
+          {!!seedWords && (
             <Controller
               control={control}
               name="confirm"
@@ -74,7 +73,7 @@ const FinalDialog: FC<Props> = ({ setupPhase, seedWords, callback }) => {
           <article className="justify-center flex flex-col items-center pb-4">
             <Button
               type="submit"
-              isDisabled={!isValid || !isSetupRecovery}
+              isDisabled={!isValid && !!seedWords}
               color="primary"
             >
               {t("setup.final_do_reboot")}


### PR DESCRIPTION
- SetupPhase seems not correct
- Falling back to only check for set/unset seedwords
- Also fixing an issue with unset seedwords when splitting

Still learning about the setup steps and what the API might send. Currently fixing things blind.  
Tested it with the mocks as good a possible.