### PR TITLE
login again if token still valid after page reload

### DIFF
--- a/backend-mock/auth.js
+++ b/backend-mock/auth.js
@@ -3,11 +3,10 @@ require("dotenv").config();
 
 const signToken = () => {
   console.info("call to signToken");
-  const token = jwt.sign(
+  return jwt.sign(
     { user_id: "admin", expires: Date.now() + 630_000 },
-    process.env.JWT_SECRET,
+    process.env.JWT_SECRET || "secret",
   );
-  return token;
 };
 
 module.exports = { signToken };

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,7 +1,7 @@
 module.exports = {
   plugins: {
-    'postcss-import': {},
-    'tailwindcss/nesting': {},
+    "postcss-import": {},
+    "tailwindcss/nesting": {},
     tailwindcss: {},
     autoprefixer: {},
   },

--- a/src/context/app-context.tsx
+++ b/src/context/app-context.tsx
@@ -97,6 +97,12 @@ const AppContextProvider: FC<PropsWithChildren> = ({ children }) => {
         const payload = parseJwt(token);
         if (payload.expires > Date.now()) {
           setIsLoggedIn(true);
+          if (
+            window.location.pathname === "/" ||
+            window.location.pathname === "/login"
+          ) {
+            return navigate("/home");
+          }
         } else {
           localStorage.removeItem(ACCESS_TOKEN);
           console.info(`Token expired at ${payload.expires}.`);
@@ -106,7 +112,7 @@ const AppContextProvider: FC<PropsWithChildren> = ({ children }) => {
         console.info(`Token invalid - removed.`);
       }
     }
-  }, [i18n]);
+  }, [i18n, navigate]);
 
   const contextValue: AppContextType = {
     isLoggedIn,

--- a/src/hooks/use-sse.tsx
+++ b/src/hooks/use-sse.tsx
@@ -198,11 +198,9 @@ function useSSE() {
       });
     };
 
-    const eventErrorHandler = (_: Event) => {
-      // just logout if there is an error and connection was closed
-      if (evtSource?.CLOSED) {
-        appCtx.logout();
-      }
+    const eventErrorHandler = (event: Event) => {
+      // inform the user about the error
+      toast.error("An SSE error occurred", { toastId: "sse-error" });
     };
 
     if (evtSource) {

--- a/tests/fixtures/login-page.ts
+++ b/tests/fixtures/login-page.ts
@@ -1,22 +1,28 @@
-import type {Locator, Page} from '@playwright/test';
-import {fulfillRoute} from "../utils";
-import {dashboardStatus} from "../status";
+// @ts-ignore
+import { signToken } from "../../backend-mock/auth";
+import { dashboardStatus } from "../status";
+import { fulfillRoute } from "../utils";
+import type { Locator, Page } from "@playwright/test";
 
 export class LoginPage {
-    private readonly passwordInput: Locator;
-    private readonly loginButton: Locator;
+  private readonly passwordInput: Locator;
+  private readonly loginButton: Locator;
 
-    constructor(public readonly page: Page) {
-        this.passwordInput = this.page.getByPlaceholder('Password A');
-        this.loginButton = page.getByRole("button", {name: "Log in"});
-    }
+  constructor(public readonly page: Page) {
+    this.passwordInput = this.page.getByPlaceholder("Password A");
+    this.loginButton = page.getByRole("button", { name: "Log in" });
+  }
 
-    async login(page: Page) {
-        await page.route("**/api/setup/status", (route) => fulfillRoute(route, dashboardStatus));
-        await this.page.route("**/api/system/login", (route) => route.fulfill({body: "someToken"}));
-        await this.page.goto("/");
+  async login(page: Page) {
+    await page.route("**/api/setup/status", (route) =>
+      fulfillRoute(route, dashboardStatus),
+    );
+    await this.page.route("**/api/system/login", (route) =>
+      route.fulfill({ body: signToken() }),
+    );
+    await this.page.goto("/");
 
-        await this.passwordInput.fill("password");
-        await this.loginButton.click();
-    }
+    await this.passwordInput.fill("password");
+    await this.loginButton.click();
+  }
 }

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,20 +1,80 @@
-import {test as base, expect} from '@playwright/test';
-import {LoginPage} from "./fixtures/login-page";
+import { LoginPage } from "./fixtures/login-page";
+import { fulfillRoute } from "./utils";
+import { test as base, expect } from "@playwright/test";
 
 type MyFixtures = {
-    loginPage: LoginPage;
+  loginPage: LoginPage;
 };
 
 const test = base.extend<MyFixtures>({
-    loginPage: async ({page}, use) => {
-        const loginPage = new LoginPage(page);
-        await loginPage.login(page);
+  loginPage: async ({ page }, use) => {
+    const loginPage = new LoginPage(page);
+    await loginPage.login(page);
 
-        await use(loginPage);
-    },
+    await use(loginPage);
+  },
 });
 
-test('should route to home', async ({loginPage, page}) => {
-    await page.waitForURL("/home");
-    await expect(page).toHaveURL("/home");
+test.beforeEach(async ({ page }) => {
+  await page.route("**/api/lightning/list-all-tx?reversed=true", (route) =>
+    fulfillRoute(route, []),
+  );
+  // mock a sse connection - needs to be improved
+  await page.route("**/api/sse/subscribe", (route) => {
+    const events = [
+      `event: system_startup_info\n data: ${JSON.stringify({
+        bitcoin: "done",
+        bitcoin_msg: "",
+        lightning: "",
+        lightning_msg: "",
+      })}`,
+    ];
+
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      headers: {
+        Connection: "keep-alive",
+        "Cache-Control": "no-cache",
+      },
+      body: events[0],
+    });
+  });
+});
+
+test("should route to home and save token after login", async ({
+  loginPage,
+  page,
+}) => {
+  await page.waitForURL("/home");
+  await expect(page).toHaveURL("/home");
+  expect(
+    await page.evaluate((_) => localStorage.getItem("access_token")),
+  ).toMatch("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
+});
+
+test("should login automatically if token is not expired", async ({
+  loginPage,
+  page,
+}) => {
+  await page.waitForURL("/home");
+  await expect(page).toHaveURL("/home");
+
+  await page.reload();
+  await page.waitForURL("/home");
+  await expect(page).toHaveURL("/home");
+  await expect(page.getByRole("link", { name: "Home" })).toBeVisible();
+});
+
+test("redirect to home if token is not expired & login page was called", async ({
+  loginPage,
+  page,
+}) => {
+  await page.waitForURL("/home");
+  await expect(page).toHaveURL("/home");
+
+  await page.goto("/login");
+  await page.waitForURL("/home");
+  await expect(page).toHaveURL("/home");
+  await expect(page.getByRole("link", { name: "Home" })).toBeVisible();
 });

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,31 +1,41 @@
-import {expect, test} from "@playwright/test";
-import {fulfillRoute} from "./utils";
-import {dashboardStatus} from "./status";
+import { dashboardStatus } from "./status";
+import { fulfillRoute } from "./utils";
+import { expect, test } from "@playwright/test";
 
 test.describe("login", () => {
-    test.beforeEach(async ({page}) => {
-        await page.route("**/api/setup/status", (route) => fulfillRoute(route, dashboardStatus));
-    });
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/setup/status", (route) =>
+      fulfillRoute(route, dashboardStatus),
+    );
+  });
 
-    test("login with correct password", async ({page}) => {
-        await page.route("**/api/system/login", (route) => route.fulfill({body: "someToken"}));
-        await page.goto("/");
+  test("login with correct password", async ({ page }) => {
+    await page.route("**/api/system/login", (route) =>
+      route.fulfill({ body: "someToken" }),
+    );
+    await page.goto("/");
 
-        await page.getByPlaceholder("Password A").fill("password");
-        await page.getByRole("button", {name: "Log in"}).click();
+    await page.getByPlaceholder("Password A").fill("password");
+    await page.getByRole("button", { name: "Log in" }).click();
 
-        await page.waitForURL("/home");
-        await expect(page).toHaveURL("/home");
-    });
+    await page.waitForURL("/home");
+    await expect(page).toHaveURL("/home");
+  });
 
-    test("login with wrong password", async ({page}) => {
-        await page.route("**/api/system/login", (route) => route.fulfill({status: 401}));
-        await page.goto("/");
+  test("login with wrong password", async ({ page }) => {
+    await page.route("**/api/system/login", (route) =>
+      route.fulfill({ status: 401 }),
+    );
+    await page.goto("/");
 
-        await page.getByPlaceholder("Password A",).fill("password");
-        await page.getByRole("button", {name: "Log in"}).click();
+    await page.getByPlaceholder("Password A").fill("password");
+    await page.getByRole("button", { name: "Log in" }).click();
 
-        await expect(page.getByText("An error occurred: Unknown error. The response was: 401 Unauthorized.")).toBeVisible();
-        await expect(page).toHaveURL("/");
-    });
+    await expect(
+      page.getByText(
+        "An error occurred: Unknown error. The response was: 401 Unauthorized.",
+      ),
+    ).toBeVisible();
+    await expect(page).toHaveURL("/");
+  });
 });

--- a/tests/setup.spec.ts
+++ b/tests/setup.spec.ts
@@ -1,41 +1,60 @@
-import {test} from "@playwright/test";
-import {fulfillRoute} from "./utils";
-import {setupStartInfo, setupStatus} from "./status";
+import { setupStartInfo, setupStatus } from "./status";
+import { fulfillRoute } from "./utils";
+import { test } from "@playwright/test";
 
-test("simple setup path", async ({page}) => {
+test("simple setup path", async ({ page }) => {
+  await page.route("**/api/setup/status", (route) =>
+    fulfillRoute(route, setupStatus),
+  );
+  await page.route("**/api/setup/setup-start-info", (route) =>
+    fulfillRoute(route, setupStartInfo),
+  );
 
-    await page.route("**/api/setup/status", (route) => fulfillRoute(route, setupStatus));
-    await page.route("**/api/setup/setup-start-info", (route) => fulfillRoute(route, setupStartInfo));
+  await page.goto("/");
 
-    await page.goto("/");
+  await page.getByLabel("Fresh Setup").click({ force: true });
+  await page.getByRole("button", { name: "Continue" }).click();
+  await page.getByRole("button", { name: "Yes, delete all data" }).click();
 
-    await page.getByLabel("Fresh Setup").click({force: true});
-    await page.getByRole("button", {name: "Continue"}).click();
-    await page.getByRole("button", {name: "Yes, delete all data"}).click();
+  await page.getByLabel("Node Name").fill("BlueNode");
+  await page.getByRole("button", { name: "Continue" }).click();
 
-    await page.getByLabel("Node Name").fill("BlueNode");
-    await page.getByRole("button", {name: "Continue"}).click();
+  await page
+    .getByLabel("Bitcoin Full Node with Lightning LND Implementation ")
+    .click({ force: true });
+  await page.getByRole("button", { name: "Continue" }).click();
 
-    await page.getByLabel("Bitcoin Full Node with Lightning LND Implementation ").click({force: true});
-    await page.getByRole("button", {name: "Continue"}).click();
+  await page.getByLabel("Node Password", { exact: true }).fill("node12345");
+  await page
+    .getByLabel("Repeat Node Password", { exact: true })
+    .fill("node12345");
+  await page.getByRole("button", { name: "Continue" }).click();
 
-    await page.getByLabel("Node Password", {exact: true}).fill("node12345");
-    await page.getByLabel("Repeat Node Password", {exact: true}).fill("node12345");
-    await page.getByRole("button", {name: "Continue"}).click();
+  page.getByAltText("Set your Apps password");
+  await page.getByLabel("Apps Password", { exact: true }).fill("apps12345");
+  await page
+    .getByLabel("Repeat Apps Password", { exact: true })
+    .fill("apps12345");
+  await page.getByRole("button", { name: "Continue" }).click();
 
-    page.getByAltText("Set your Apps password");
-    await page.getByLabel("Apps Password", {exact: true}).fill("apps12345");
-    await page.getByLabel("Repeat Apps Password", {exact: true}).fill("apps12345");
-    await page.getByRole("button", {name: "Continue"}).click();
+  await page.getByLabel("Wallet Password", { exact: true }).fill("wallet12345");
+  await page
+    .getByLabel("Repeat Wallet Password", { exact: true })
+    .fill("wallet12345");
+  await page.getByRole("button", { name: "Continue" }).click();
 
-    await page.getByLabel("Wallet Password", {exact: true}).fill("wallet12345");
-    await page.getByLabel("Repeat Wallet Password", {exact: true}).fill("wallet12345");
-    await page.getByRole("button", {name: "Continue"}).click();
+  await page.route("**/api/setup/setup-start-done", (route) =>
+    fulfillRoute(route, "STATUS"),
+  );
+  await page.route("**/api/setup/status", (route) =>
+    fulfillRoute(route, setupStatus),
+  );
 
-    await page.route("**/api/setup/setup-start-done", (route) => fulfillRoute(route, "STATUS"));
-    await page.route("**/api/setup/status", (route) => fulfillRoute(route, setupStatus));
-
-    await page.getByRole("button", {name: "Start setup"}).click();
-    await page.route("**/api/setup/status", (route) => fulfillRoute(route, setupStatus));
-    await page.route("**/api/setup/setup-start-info", (route) => fulfillRoute(route, setupStartInfo));
+  await page.getByRole("button", { name: "Start setup" }).click();
+  await page.route("**/api/setup/status", (route) =>
+    fulfillRoute(route, setupStatus),
+  );
+  await page.route("**/api/setup/setup-start-info", (route) =>
+    fulfillRoute(route, setupStartInfo),
+  );
 });

--- a/tests/status.ts
+++ b/tests/status.ts
@@ -1,20 +1,20 @@
 export const setupStatus = {
-    setupPhase: "setup",
-    state: "waitsetup",
-    message: "Node Running",
-    initialsync: "",
+  setupPhase: "setup",
+  state: "waitsetup",
+  message: "Node Running",
+  initialsync: "",
 };
 
 export const setupStartInfo = {
-    setupPhase: "setup",
-    hddGotBlockchain: "0",
-    hddGotMigrationData: null,
-    migrationMode: null,
+  setupPhase: "setup",
+  hddGotBlockchain: "0",
+  hddGotMigrationData: null,
+  migrationMode: null,
 };
 
 export const dashboardStatus = {
-    setupPhase: "done",
-    state: "waitfinal",
-    message: "Node Running",
-    initialsync: "",
+  setupPhase: "done",
+  state: "waitfinal",
+  message: "Node Running",
+  initialsync: "",
 };

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,5 +1,5 @@
-import {Route} from "@playwright/test";
+import { Route } from "@playwright/test";
 
 export const fulfillRoute = async (route: Route, json: any) => {
-    await route.fulfill({json});
+  await route.fulfill({ json });
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,8 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "types": [
-      "vite/client",
-      "vite-plugin-svgr/client",
-      "vitest/globals"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "types": ["vite/client", "vite-plugin-svgr/client", "vitest/globals"],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -26,15 +18,9 @@
     "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
-      "test-utils": [
-        "src/utils/test-utils"
-      ],
-      "@/*": [
-        "src/*"
-      ]
+      "test-utils": ["src/utils/test-utils"],
+      "@/*": ["src/*"]
     }
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,9 @@
 /// <reference types="vitest" />
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import eslint from "vite-plugin-eslint";
 import svgr from "vite-plugin-svgr";
 import viteTsconfigPaths from "vite-tsconfig-paths";
-import eslint from "vite-plugin-eslint";
 
 const BACKEND_SERVER = "http://localhost:8000";
 
@@ -15,9 +15,9 @@ export default defineConfig({
     rollupOptions: {
       output: {
         // see https://github.com/vitejs/vite/issues/11804#issuecomment-2009619365
-        chunkFileNames: 'chunk-[hash].js'
-      }
-    }
+        chunkFileNames: "chunk-[hash].js",
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
closes #751 

When reloading the page, the SSE connection is closed, thus the `eventErrorHandler` in `use-sse` was fired and logout was called, which deleted the token.

Now I'm showing a error toast if the sse connection was closed.

Ran prettier as well, don't know why it didn't format that stuff before.