### PR TITLE
feat(settings): use next-ui on overview

### DIFF
--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -205,7 +205,7 @@
     "settings": {
       "cancel": "Cancel",
       "change": "Change",
-      "change_pw_a": "Change password A",
+      "change_pw_a": "Change Node Password (A)",
       "confirm": "Confirm",
       "curr_lang": "Current language",
       "language": "Language",

--- a/src/pages/Settings/ActionBox.tsx
+++ b/src/pages/Settings/ActionBox.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/Button";
 import type { FC, PropsWithChildren, ReactElement } from "react";
 
 export type Props = {
@@ -25,11 +26,11 @@ const ActionBox: FC<PropsWithChildren<Props>> = ({
         <article className="relative rounded p-5 shadow-xl bg-gray-800">
           <div className="flex justify-between">
             <h4 className="flex w-1/2 items-center font-bold xl:w-2/3">
-              <span>{name}</span>
+              {name}
             </h4>
-            <button className="bd-button w-1/2 py-1 xl:w-1/3" onClick={action}>
+            <Button onClick={action} color="secondary" variant="flat">
               {actionName}
-            </button>
+            </Button>
           </div>
         </article>
       </div>

--- a/src/pages/Settings/DebugLogBox.tsx
+++ b/src/pages/Settings/DebugLogBox.tsx
@@ -1,8 +1,7 @@
-import ButtonWithSpinner from "@/components/ButtonWithSpinner/ButtonWithSpinner";
+import { Button } from "@/components/Button";
 import { AppContext } from "@/context/app-context";
 import { checkError } from "@/utils/checkError";
 import { instance } from "@/utils/interceptor";
-import { DocumentTextIcon } from "@heroicons/react/24/outline";
 import { FC, useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
@@ -46,16 +45,16 @@ const DebugLogBox: FC = () => {
           <h4 className="flex w-1/2 items-center font-bold xl:w-2/3">
             {t("settings.generate_debug")}
           </h4>
-          <ButtonWithSpinner
-            loading={isGeneratingReport}
+          <Button
+            isLoading={isGeneratingReport}
             onClick={onClickHandler}
-            icon={<DocumentTextIcon className="mr-1 inline h-5 w-5" />}
-            className="bd-button w-1/2 py-1 xl:w-1/3"
+            color="secondary"
+            variant="flat"
           >
             {isGeneratingReport
               ? t("settings.generating")
               : t("settings.generate")}
-          </ButtonWithSpinner>
+          </Button>
         </div>
       </article>
     </div>


### PR DESCRIPTION
- overview only
- not the functional-modals triggered by the actions

<img width="1496" alt="image" src="https://github.com/user-attachments/assets/9dc9da73-f694-49e1-a7e7-39d5cc47345a">
