### PR TITLE
feat(settings): use next-ui on reboot-action

### DIFF
--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -10,14 +10,16 @@ import type { UseDisclosureReturn } from "@nextui-org/use-disclosure";
 import { useTranslation } from "react-i18next";
 
 export type Props = {
-  confirmText: string;
+  headline: string;
+  body?: string;
   onConfirm: () => void;
   disclosure: UseDisclosureReturn;
   isLoading?: boolean;
 };
 
 export const ConfirmModal = ({
-  confirmText,
+  headline,
+  body,
   onConfirm,
   disclosure,
   isLoading,
@@ -32,9 +34,11 @@ export const ConfirmModal = ({
           {(onClose) => (
             <>
               <ModalHeader className="flex flex-col gap-1">
-                {t("settings.confirm")}
+                {headline}
               </ModalHeader>
-              <ModalBody>{confirmText}</ModalBody>
+
+              {!!body && <ModalBody>{body}</ModalBody>}
+
               <ModalFooter>
                 <Button variant="light" onClick={onClose} disabled={isLoading}>
                   {t("settings.cancel")}

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -13,9 +13,15 @@ export type Props = {
   confirmText: string;
   onConfirm: () => void;
   disclosure: UseDisclosureReturn;
+  isLoading?: boolean;
 };
 
-export const ConfirmModal = ({ confirmText, onConfirm, disclosure }: Props) => {
+export const ConfirmModal = ({
+  confirmText,
+  onConfirm,
+  disclosure,
+  isLoading,
+}: Props) => {
   const { t } = useTranslation();
   const { isOpen, onOpenChange, onClose } = disclosure;
 
@@ -30,10 +36,15 @@ export const ConfirmModal = ({ confirmText, onConfirm, disclosure }: Props) => {
               </ModalHeader>
               <ModalBody>{confirmText}</ModalBody>
               <ModalFooter>
-                <Button variant="light" onClick={onClose}>
+                <Button variant="light" onClick={onClose} disabled={isLoading}>
                   {t("settings.cancel")}
                 </Button>
-                <Button color="primary" onClick={onConfirm}>
+                <Button
+                  color="primary"
+                  onClick={onConfirm}
+                  disabled={isLoading}
+                  isLoading={isLoading}
+                >
                   {t("settings.confirm")}
                 </Button>
               </ModalFooter>

--- a/src/pages/Settings/RebootModal.tsx
+++ b/src/pages/Settings/RebootModal.tsx
@@ -1,25 +1,21 @@
-import LoadingSpinner from "@/components/LoadingSpinner/LoadingSpinner";
+import ActionBox from "./ActionBox";
+import ConfirmModal from "@/components/ConfirmModal";
 import { AppContext } from "@/context/app-context";
-import ModalDialog from "@/layouts/ModalDialog";
-import { MODAL_ROOT } from "@/utils";
 import { instance } from "@/utils/interceptor";
+import { useDisclosure } from "@nextui-org/react";
 import { HttpStatusCode } from "axios";
 import { FC, useContext, useState } from "react";
-import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 
-export type Props = {
-  onClose: () => void;
-};
-
 const confirmEndpoint = "/system/reboot";
 
-const RebootModal: FC<Props> = ({ onClose }) => {
+const RebootModal: FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const { t } = useTranslation();
   const { setIsLoggedIn } = useContext(AppContext);
   const navigate = useNavigate();
+  const confirmModal = useDisclosure();
 
   const rebootHandler = async () => {
     setIsLoading(true);
@@ -31,32 +27,22 @@ const RebootModal: FC<Props> = ({ onClose }) => {
     }
   };
 
-  return createPortal(
-    <ModalDialog close={onClose}>
-      {isLoading && (
-        <div className="my-2 flex justify-center">
-          <LoadingSpinner />
-        </div>
-      )}
-      <p>{t("settings.reboot") + "?"}</p>
-      <div className="flex flex-col p-3 xl:flex-row">
-        <button
-          className="m-2 h-10 w-full rounded bg-gray-500 text-center text-white hover:bg-gray-400 disabled:bg-gray-500 xl:w-1/2"
-          onClick={onClose}
-          disabled={isLoading}
-        >
-          {t("settings.cancel")}
-        </button>
-        <button
-          className="m-2 h-10 w-full rounded bg-gray-500 text-center text-white hover:bg-gray-400 disabled:bg-gray-500 xl:w-1/2"
-          onClick={rebootHandler}
-          disabled={isLoading}
-        >
-          {t("settings.confirm")}
-        </button>
-      </div>
-    </ModalDialog>,
-    MODAL_ROOT,
+  return (
+    <>
+      <ConfirmModal
+        disclosure={confirmModal}
+        confirmText={t("settings.reboot")}
+        onConfirm={rebootHandler}
+        isLoading={isLoading}
+      />
+
+      <ActionBox
+        name={t("settings.reboot")}
+        actionName={t("settings.reboot")}
+        action={() => confirmModal.onOpen()}
+        showChild={false}
+      />
+    </>
   );
 };
 

--- a/src/pages/Settings/RebootModal.tsx
+++ b/src/pages/Settings/RebootModal.tsx
@@ -31,7 +31,7 @@ const RebootModal: FC = () => {
     <>
       <ConfirmModal
         disclosure={confirmModal}
-        confirmText={t("settings.reboot")}
+        headline={t("settings.reboot")}
         onConfirm={rebootHandler}
         isLoading={isLoading}
       />

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -9,13 +9,10 @@ import { enableGutter } from "@/utils";
 import { FC, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-/**
- * Displays the settings page.
- */
 const Settings: FC = () => {
   const { t } = useTranslation();
+
   const [showShutdownModal, setShowShutdownModal] = useState(false);
-  const [showRebootModal, setShowRebootModal] = useState(false);
   const [showPwModal, setShowPwModal] = useState(false);
 
   useEffect(() => {
@@ -33,14 +30,7 @@ const Settings: FC = () => {
       >
         <ChangePwModal onClose={() => setShowPwModal(false)} />
       </ActionBox>
-      <ActionBox
-        name={t("settings.reboot")}
-        actionName={t("settings.reboot")}
-        action={() => setShowRebootModal(true)}
-        showChild={showRebootModal}
-      >
-        <RebootModal onClose={() => setShowRebootModal(false)} />
-      </ActionBox>
+      <RebootModal />
       <ActionBox
         name={t("settings.shutdown")}
         actionName={t("settings.shutdown")}

--- a/src/pages/Setup/FormatDialog.tsx
+++ b/src/pages/Setup/FormatDialog.tsx
@@ -27,7 +27,7 @@ export default function FormatDialog({ containsBlockchain, callback }: Props) {
     <>
       <ConfirmModal
         disclosure={confirmModal}
-        confirmText={`${t("setup.cancel_setup")}?`}
+        headline={`${t("setup.cancel_setup")}?`}
         onConfirm={() => callback(false, false)}
       />
 

--- a/src/pages/Setup/InputNodeName.tsx
+++ b/src/pages/Setup/InputNodeName.tsx
@@ -42,7 +42,7 @@ export default function InputNodeName({ callback }: Props) {
     <>
       <ConfirmModal
         disclosure={confirmModal}
-        confirmText={`${t("setup.cancel_setup")}?`}
+        headline={`${t("setup.cancel_setup")}?`}
         onConfirm={() => callback(null)}
       />
 

--- a/src/pages/Setup/InputPassword.tsx
+++ b/src/pages/Setup/InputPassword.tsx
@@ -48,7 +48,7 @@ export default function InputPassword({ passwordType, callback }: Props) {
     <>
       <ConfirmModal
         disclosure={confirmModal}
-        confirmText={`${t("setup.cancel_setup")}?`}
+        headline={`${t("setup.cancel_setup")}?`}
         onConfirm={() => callback(null)}
       />
 

--- a/src/pages/Setup/MigrationDialog.tsx
+++ b/src/pages/Setup/MigrationDialog.tsx
@@ -42,7 +42,7 @@ const MigrationDialog: FC<InputData> = ({
     <>
       <ConfirmModal
         disclosure={confirmModal}
-        confirmText={`${t("setup.cancel_setup")}?`}
+        headline={`${t("setup.cancel_setup")}?`}
         onConfirm={() => callback(false)}
       />
 

--- a/src/pages/Setup/StartDoneDialog.tsx
+++ b/src/pages/Setup/StartDoneDialog.tsx
@@ -41,7 +41,7 @@ const StartDoneDialog: FC<Props> = ({ setupPhase, callback }) => {
     <>
       <ConfirmModal
         disclosure={confirmModal}
-        confirmText={`${t("setup.cancel_setup")}?`}
+        headline={`${t("setup.cancel_setup")}?`}
         onConfirm={() => callback(true)}
       />
 


### PR DESCRIPTION
Maybe we can adjust the modal to use the current body as headline and make body optional?

<img width="1226" alt="image" src="https://github.com/user-attachments/assets/1febf0c1-b2c5-44f8-9bcd-49bf2af5d2ac">
