### PR TITLE
refactor(apps): use alert for btcpay warning

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -9,8 +9,8 @@ export interface Props extends HTMLAttributes<HTMLElement> {
 
 const colors = {
   success: "text-success border-success bg-green-900",
-  warning: "text-warning border-warning bg-red-900",
-  danger: "text-danger border-danger bg-yellow-900",
+  warning: "text-warning border-warning bg-yellow-900",
+  danger: "text-danger border-danger bg-red-900",
   info: "text-primary border-primary bg-blue-900",
 };
 

--- a/src/pages/Apps/AppInfo.tsx
+++ b/src/pages/Apps/AppInfo.tsx
@@ -1,4 +1,5 @@
 import ImageCarousel from "./ImageCarousel";
+import { Alert } from "@/components/Alert";
 import AppIcon from "@/components/AppIcon";
 import { SSEContext } from "@/context/sse-context";
 import PageLoadingScreen from "@/layouts/PageLoadingScreen";
@@ -150,9 +151,9 @@ export const AppInfo: FC = () => {
       </section>
 
       {showBtcPayWarning && (
-        <p className="text-center text-warning py-2">
-          {t("appInfo.btcpayserver.ram_warning")}
-        </p>
+        <div className="m-5">
+          <Alert color="warning">{t("appInfo.btcpayserver.ram_warning")}</Alert>
+        </div>
       )}
 
       <section className="text-center">


### PR DESCRIPTION
- fix: alert colors

Using our "new" Alert-component:  

<img width="1546" alt="image" src="https://github.com/user-attachments/assets/045aab3f-7ce6-4927-b8b4-7b72c4b28adb">
