### PR TITLE
feat: add documentation button to setup

### DIFF
--- a/src/layouts/SetupContainer.tsx
+++ b/src/layouts/SetupContainer.tsx
@@ -1,5 +1,7 @@
 import I18nSelect from "@/components/I18nDropdown";
 import Stepper from "@/pages/Setup/Stepper";
+import { BookOpenIcon } from "@heroicons/react/24/outline";
+import { Chip } from "@nextui-org/react";
 import { PropsWithChildren } from "react";
 
 type Props = {
@@ -12,12 +14,21 @@ export default function SetupContainer({
 }: PropsWithChildren<Props>) {
   return (
     <main className="flex min-h-screen h-full w-screen flex-col items-center justify-center bg-primary-900 transition-colors text-white">
-      <div className="fixed right-16 top-4 flex h-8 w-48 items-center justify-around">
+      <div className="fixed md:right-16 top-16 md:top-8 flex h-8 w-48 md:w-96 md:flex-row flex-col-reverse gap-6 md:gap-4 justify-center items-center">
+        <a href="https://docs.raspiblitz.org/" target="_blank" rel="noreferrer">
+          <Chip
+            color="primary"
+            className="p-4"
+            startContent={<BookOpenIcon className="w-5 h-5" />}
+          >
+            Documentation
+          </Chip>
+        </a>
         <I18nSelect />
       </div>
 
       {currentStep !== null && (
-        <div className="fixed mb-4 top-12 flex items-center justify-around w-1/3">
+        <div className="fixed mb-4 top-24 flex items-center justify-around w-1/3">
           <Stepper currentStep={currentStep} />
         </div>
       )}

--- a/src/layouts/SetupContainer.tsx
+++ b/src/layouts/SetupContainer.tsx
@@ -1,7 +1,7 @@
+import { Button } from "@/components/Button";
 import I18nSelect from "@/components/I18nDropdown";
 import Stepper from "@/pages/Setup/Stepper";
 import { BookOpenIcon } from "@heroicons/react/24/outline";
-import { Chip } from "@nextui-org/react";
 import { PropsWithChildren } from "react";
 
 type Props = {
@@ -15,15 +15,18 @@ export default function SetupContainer({
   return (
     <main className="flex min-h-screen h-full w-screen flex-col items-center justify-center bg-primary-900 transition-colors text-white">
       <div className="fixed md:right-16 top-16 md:top-8 flex h-8 w-48 md:w-96 md:flex-row flex-col-reverse gap-6 md:gap-4 justify-center items-center">
-        <a href="https://docs.raspiblitz.org/" target="_blank" rel="noreferrer">
-          <Chip
-            color="primary"
-            className="p-4"
-            startContent={<BookOpenIcon className="w-5 h-5" />}
-          >
-            Documentation
-          </Chip>
-        </a>
+        <Button
+          as="a"
+          href="https://docs.raspiblitz.org/"
+          target="_blank"
+          rel="noreferrer"
+          color="primary"
+          variant="ghost"
+          className="p-4 w-full"
+          startContent={<BookOpenIcon className="w-5 h-5" />}
+        >
+          Documentation
+        </Button>
         <I18nSelect />
       </div>
 

--- a/src/pages/Apps/AppInfo.tsx
+++ b/src/pages/Apps/AppInfo.tsx
@@ -177,7 +177,7 @@ export const AppInfo: FC = () => {
           <Link
             href={repository}
             target="_blank"
-            rel="noreferrer noopener"
+            rel="noreferrer"
             underline="always"
           >
             {repository}

--- a/src/pages/Setup/LightningDialog.tsx
+++ b/src/pages/Setup/LightningDialog.tsx
@@ -52,7 +52,7 @@ export default function LightningDialog({ callback }: Props) {
                   href="https://docs.raspiblitz.org/docs/setup/software-setup/basic"
                   className="text-primary underline"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noreferrer"
                 ></a>,
               ]}
             />


### PR DESCRIPTION
## Desktop
### before
![before_desktop](https://github.com/user-attachments/assets/0f8c354a-f374-480b-840f-70d5d6260a6d)

### after
![after_desktop](https://github.com/user-attachments/assets/559d79b6-219e-4fac-a739-6934d38a0b77)

## Mobile
### before
![before_mobile](https://github.com/user-attachments/assets/bf33f03e-45d7-4c54-99de-13885f19456a)

### after
![after_mobile](https://github.com/user-attachments/assets/6b6a0d50-d4d7-43a6-ab76-6f0ccd475336)


Also removed the `noopener` for the `_blank` links, since `noreferrer` already includes them.
https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer