### PR TITLE
Adding documentation routing on SideDrawer.tsx as well as Header.tsx

### DIFF
--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -203,6 +203,7 @@
       "display_btc": "Display BTC",
       "home": "Home",
       "logout": "Log out",
+      "documentation": "Documentation",
       "settings": "Settings"
     },
     "settings": {

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -75,6 +75,9 @@ export default function Header() {
             <DropdownItem
               key="documentation"
               href="https://docs.raspiblitz.org/docs/intro"
+              target="_blank"
+              rel="noopener noreferrer"
+              color="warning"
               startContent={<BookOpenIcon className="h-5 w-5" />}
             >
               Documentation

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -6,6 +6,7 @@ import {
   SatoshiV1Icon,
   BitcoinCircleIcon,
 } from "@bitcoin-design/bitcoin-icons-react/filled";
+import { BookOpenIcon } from "@heroicons/react/24/outline";
 import { Bars3Icon } from "@heroicons/react/24/outline";
 import { ArrowRightStartOnRectangleIcon } from "@heroicons/react/24/outline";
 import {
@@ -69,6 +70,16 @@ export default function Header() {
                 ? t("navigation.display_btc")
                 : t("navigation.display_sats")}
             </DropdownItem>
+
+            {/* Adding the documentation redirecting */}
+            <DropdownItem
+              key="documentation"
+              href="https://docs.raspiblitz.org/docs/intro"
+              startContent={<BookOpenIcon className="h-5 w-5" />}
+            >
+              Documentation
+            </DropdownItem>
+
             <DropdownItem
               key="logout"
               color="danger"

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -70,8 +70,6 @@ export default function Header() {
                 ? t("navigation.display_btc")
                 : t("navigation.display_sats")}
             </DropdownItem>
-
-            {/* Adding the documentation redirecting */}
             <DropdownItem
               key="documentation"
               href="https://docs.raspiblitz.org/docs/intro"
@@ -80,7 +78,7 @@ export default function Header() {
               color="warning"
               startContent={<BookOpenIcon className="h-5 w-5" />}
             >
-              Documentation
+              {t("navigation.documentation")}
             </DropdownItem>
 
             <DropdownItem

--- a/src/layouts/SideDrawer.tsx
+++ b/src/layouts/SideDrawer.tsx
@@ -2,6 +2,7 @@ import AppIcon from "@/components/AppIcon";
 import AppStatusItem from "@/components/AppStatusItem";
 import { AppContext } from "@/context/app-context";
 import { SSEContext } from "@/context/sse-context";
+import { BookOpenIcon } from "@heroicons/react/24/outline";
 import {
   ArrowRightStartOnRectangleIcon,
   Cog6ToothIcon,
@@ -46,25 +47,15 @@ export const SideDrawer: FC = () => {
             {t("navigation.settings")}
           </span>
         </NavLink>
-
-        {/* Beginning of the documentation icon feature */}
         <NavLink
           to="https://docs.raspiblitz.org/docs/intro"
           target="_blank"
           rel="noopener noreferrer"
           className={(props) => createClassName(props)}
         >
-          {/* <AppStatusItem></AppStatusItem> */}
-          <img
-            className={`h-19 inline w-10`}
-            src={`./logo192.png`}
-            onError={(e) => {
-              (e.target as HTMLImageElement).src = "/assets/cloud.svg";
-            }}
-            alt={`RaspiBlitz Logo`}
-          />
+          <BookOpenIcon className={navIconClasses} />
           <span className="mx-3 w-1/2 justify-center text-lg">
-            Documentation
+            {t("navigation.documentation")}
           </span>
         </NavLink>
 

--- a/src/layouts/SideDrawer.tsx
+++ b/src/layouts/SideDrawer.tsx
@@ -50,6 +50,8 @@ export const SideDrawer: FC = () => {
         {/* Beginning of the documentation icon feature */}
         <NavLink
           to="https://docs.raspiblitz.org/docs/intro"
+          target="_blank"
+          rel="noopener noreferrer"
           className={(props) => createClassName(props)}
         >
           {/* <AppStatusItem></AppStatusItem> */}

--- a/src/layouts/SideDrawer.tsx
+++ b/src/layouts/SideDrawer.tsx
@@ -1,3 +1,4 @@
+import AppIcon from "@/components/AppIcon";
 import AppStatusItem from "@/components/AppStatusItem";
 import { AppContext } from "@/context/app-context";
 import { SSEContext } from "@/context/sse-context";
@@ -45,6 +46,26 @@ export const SideDrawer: FC = () => {
             {t("navigation.settings")}
           </span>
         </NavLink>
+
+        {/* Beginning of the documentation icon feature */}
+        <NavLink
+          to="https://docs.raspiblitz.org/docs/intro"
+          className={(props) => createClassName(props)}
+        >
+          {/* <AppStatusItem></AppStatusItem> */}
+          <img
+            className={`h-19 inline w-10`}
+            src={`./logo192.png`}
+            onError={(e) => {
+              (e.target as HTMLImageElement).src = "/assets/cloud.svg";
+            }}
+            alt={`RaspiBlitz Logo`}
+          />
+          <span className="mx-3 w-1/2 justify-center text-lg">
+            Documentation
+          </span>
+        </NavLink>
+
         {appStatus
           .filter((app) => app.installed)
           .map((app) => (


### PR DESCRIPTION
With my PR, I intend to close #785 . The modification asked was to include easy and direct access to documentation somewhere in the main app interface as well. Judging so, I decided to add documentation routing to the ```src/layouts/SideDrawer.tsx``` component which makes it visible on big screens (desktop, laptop) and currently looks like this:


![RaspiBlitz1](https://github.com/user-attachments/assets/c86ea8ca-1bd4-488c-9ee1-5831b27aad5f)


The 'Documentation' option contains the RaspiBlitz logo as well as redirects to <a href="https://docs.raspiblitz.org/docs/intro"> the actual documentation</a> by opening a new tab.


The 2nd thing I did was to include the documentation in the drop down menu of ```src/layouts/Header.tsx``` as well. This way since the side drawer isn't visible on smaller screens, users can directly access the documentation from the drop down menu. Currently this is how it looks in the implementation : 


![image](https://github.com/user-attachments/assets/165f7550-e87b-49f1-a2b9-e670f6d0093b)


As before, even clicking on this option redirects us to <a href="https://docs.raspiblitz.org/docs/intro"> the actual documentation</a> on a new tab.


Any more improvements, recommendations and changes are wholly welcome and I would also love blunt criticism on my PR. Thank you! 


