### PR TITLE
fix: convert tailwind to esm

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,33 +1,31 @@
-const { nextui } = require("@nextui-org/react");
+import { nextui } from "@nextui-org/react";
 
 /** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: [
-    "./src/**/*.{js,jsx,ts,tsx}",
-    "./public/index.html",
-    "./node_modules/@nextui-org/theme/dist/**/*.{js,ts,jsx,tsx}",
-  ],
-  theme: {
-    extend: {
-      colors: {
-        "bd-yellow-light": "#F7CB47",
-        "bd-yellow-dark": "#F7CB47",
-      },
+export const content = [
+  "./src/**/*.{js,jsx,ts,tsx}",
+  "./public/index.html",
+  "./node_modules/@nextui-org/theme/dist/**/*.{js,ts,jsx,tsx}",
+];
+export const theme = {
+  extend: {
+    colors: {
+      "bd-yellow-light": "#F7CB47",
+      "bd-yellow-dark": "#F7CB47",
     },
   },
-  plugins: [
-    nextui({
-      addCommonColors: true,
-      themes: {
-        light: {},
-        dark: {
-          colors: {
-            primary: "#4785FF",
-            secondary: "#BBC6DC",
-            tertiary: "#253553",
-          },
+};
+export const plugins = [
+  nextui({
+    addCommonColors: true,
+    themes: {
+      light: {},
+      dark: {
+        colors: {
+          primary: "#4785FF",
+          secondary: "#BBC6DC",
+          tertiary: "#253553",
         },
       },
-    }),
-  ],
-};
+    },
+  }),
+];


### PR DESCRIPTION
`npm run dev` is somehow not working.

Converting to esm seems to work

```
file:///home/christophs/src/projects/raspiblitz-web/tailwind.config.js:1
const { nextui } = require("@nextui-org/react");
                   ^

ReferenceError: require is not defined
    at file:///home/christophs/src/projects/raspiblitz-web/tailwind.config.js:1:20
```