### PR TITLE
NixOS module support / devenv.sh dev enviroment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # production
 /build
 dist
+/result
 
 # misc
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# devenv
+.devenv*

--- a/README.md
+++ b/README.md
@@ -20,12 +20,30 @@ Big thanks to our translators, which you can find in this [README](src/i18n/READ
 
 - [Node.js](https://nodejs.org/en/download/)
 - [asdf](https://asdf-vm.com/) is supported but not required.
+- [Nix](https://nixos.org/download.html) with [Flakes](https://nixos.wiki/wiki/Flakes) enabled (optional, for devenv.sh or NixOS builds)
 
 #### Update npm dependencies
 
 ```sh
 npm update
 ```
+
+### Development with devenv.sh
+
+This project supports [devenv.sh](https://devenv.sh/), a developer environment tool built on Nix.
+
+#### Setup
+
+1. Install devenv.sh by following the instructions at https://devenv.sh/getting-started/
+2. Run `devenv shell` to enter the development environment
+3. Devenv will install the npm dependencies automatically when entering the shell. To change this behaviour, change `javascript.npm.install.enable = true;` to `false` and run `npm install` after entering the shell.
+
+#### Benefits of using devenv.sh
+
+- Consistent development environment across all contributors
+- Automatically installs the correct version of Node.js and other dependencies
+- Includes development tools like TypeScript, ESLint, and Nix utilities
+- Works on any platform that supports Nix (Linux, macOS, WSL)
 
 ### Dev workflow
 

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,8 @@
-{ lib
-, config
-, dream2nix
-, ...
+{
+  lib,
+  config,
+  dream2nix,
+  ...
 }: {
   imports = [
     dream2nix.modules.dream2nix.nodejs-package-lock-v3
@@ -12,7 +13,7 @@
     src = ./build;
   };
 
-  deps = { nixpkgs, ... }: {
+  deps = {nixpkgs, ...}: {
     inherit
       (nixpkgs)
       stdenv

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, config
+, dream2nix
+, ...
+}: {
+  imports = [
+    dream2nix.modules.dream2nix.nodejs-package-lock-v3
+    dream2nix.modules.dream2nix.nodejs-granular-v3
+  ];
+
+  mkDerivation = {
+    src = ./build;
+  };
+
+  deps = { nixpkgs, ... }: {
+    inherit
+      (nixpkgs)
+      stdenv
+      ;
+  };
+
+  nodejs-package-lock-v3 = {
+    packageLockFile = "${config.mkDerivation.src}/package-lock.json";
+  };
+
+  name = "raspiblitz-web";
+  version = "1.3.0-dev";
+}

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,103 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1742320965,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "6bde92766ddd3ee1630029a03d36baddd51934e2",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742300892,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "ea26a82dda75bee6783baca6894040c8e6599728",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733477122,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "7bd9e84d0452f6d2e63b6e6da29fe73fac951857",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,36 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}: {
+  # https://devenv.sh/languages/javascript/
+  languages = {
+    nix = {
+      enable = true;
+      lsp.package = pkgs.nixd;
+    };
+
+    javascript = {
+      enable = true;
+      npm = {
+        enable = true;
+        install.enable = true;
+      };
+    };
+
+    typescript = {
+      enable = true;
+    };
+  };
+
+  packages = [
+    pkgs.typescript
+    pkgs.eslint_d
+    pkgs.vscode-js-debug
+    pkgs.statix
+    pkgs.alejandra
+    pkgs.nixd
+    pkgs.statix
+  ];
+}

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716509168,
-        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
+        "lastModified": 1742288794,
+        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
+        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,112 @@
+{
+  "nodes": {
+    "dream2nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "purescript-overlay": "purescript-overlay",
+        "pyproject-nix": "pyproject-nix"
+      },
+      "locked": {
+        "lastModified": 1716662043,
+        "narHash": "sha256-RMw5XaEKQR7DQEFNr3f8G6Ce25ET/nafkEgY+goLoLU=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "b6a176f65988cd7a434783c938516884874d894e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716619601,
+        "narHash": "sha256-9dUxZf8MOqJH3vjbhrz7LH4qTcnRsPSBU1Q50T7q/X8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "47e03a624662ce399e55c45a5f6da698fc72c797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "purescript-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ],
+        "slimlock": "slimlock"
+      },
+      "locked": {
+        "lastModified": 1696022621,
+        "narHash": "sha256-eMjFmsj2G1E0Q5XiibUNgFjTiSz0GxIeSSzzVdoN730=",
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "rev": "047c7933abd6da8aa239904422e22d190ce55ead",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1702448246,
+        "narHash": "sha256-hFg5s/hoJFv7tDpiGvEvXP0UfFvFEDgTdyHIjDVHu1I=",
+        "owner": "davhau",
+        "repo": "pyproject.nix",
+        "rev": "5a06a2697b228c04dd2f35659b4b659ca74f7aeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "davhau",
+        "ref": "dream2nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "dream2nix": "dream2nix",
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ]
+      }
+    },
+    "slimlock": {
+      "inputs": {
+        "nixpkgs": [
+          "dream2nix",
+          "purescript-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688610262,
+        "narHash": "sha256-Wg0ViDotFWGWqKIQzyYCgayeH8s4U1OZcTiWTQYdAp4=",
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "rev": "b5c6cdcaf636ebbebd0a1f32520929394493f1a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,108 +1,57 @@
 {
   "nodes": {
-    "dream2nix": {
+    "flake-utils": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "purescript-overlay": "purescript-overlay",
-        "pyproject-nix": "pyproject-nix"
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1716662043,
-        "narHash": "sha256-RMw5XaEKQR7DQEFNr3f8G6Ce25ET/nafkEgY+goLoLU=",
-        "owner": "nix-community",
-        "repo": "dream2nix",
-        "rev": "b6a176f65988cd7a434783c938516884874d894e",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "repo": "dream2nix",
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716619601,
-        "narHash": "sha256-9dUxZf8MOqJH3vjbhrz7LH4qTcnRsPSBU1Q50T7q/X8=",
+        "lastModified": 1716509168,
+        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47e03a624662ce399e55c45a5f6da698fc72c797",
+        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "purescript-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "dream2nix",
-          "nixpkgs"
-        ],
-        "slimlock": "slimlock"
-      },
-      "locked": {
-        "lastModified": 1696022621,
-        "narHash": "sha256-eMjFmsj2G1E0Q5XiibUNgFjTiSz0GxIeSSzzVdoN730=",
-        "owner": "thomashoneyman",
-        "repo": "purescript-overlay",
-        "rev": "047c7933abd6da8aa239904422e22d190ce55ead",
-        "type": "github"
-      },
-      "original": {
-        "owner": "thomashoneyman",
-        "repo": "purescript-overlay",
-        "type": "github"
-      }
-    },
-    "pyproject-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1702448246,
-        "narHash": "sha256-hFg5s/hoJFv7tDpiGvEvXP0UfFvFEDgTdyHIjDVHu1I=",
-        "owner": "davhau",
-        "repo": "pyproject.nix",
-        "rev": "5a06a2697b228c04dd2f35659b4b659ca74f7aeb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "davhau",
-        "ref": "dream2nix",
-        "repo": "pyproject.nix",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "dream2nix": "dream2nix",
-        "nixpkgs": [
-          "dream2nix",
-          "nixpkgs"
-        ]
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
       }
     },
-    "slimlock": {
-      "inputs": {
-        "nixpkgs": [
-          "dream2nix",
-          "purescript-overlay",
-          "nixpkgs"
-        ]
-      },
+    "systems": {
       "locked": {
-        "lastModified": 1688610262,
-        "narHash": "sha256-Wg0ViDotFWGWqKIQzyYCgayeH8s4U1OZcTiWTQYdAp4=",
-        "owner": "thomashoneyman",
-        "repo": "slimlock",
-        "rev": "b5c6cdcaf636ebbebd0a1f32520929394493f1a6",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
-        "owner": "thomashoneyman",
-        "repo": "slimlock",
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "My flake with dream2nix packages";
+
+  inputs = {
+    dream2nix.url = "github:nix-community/dream2nix";
+    nixpkgs.follows = "dream2nix/nixpkgs";
+  };
+
+  outputs =
+    inputs @ { self
+    , dream2nix
+    , nixpkgs
+    , ...
+    }:
+    let
+      system = "x86_64-linux";
+    in
+    {
+      # All packages defined in ./packages/<name> are automatically added to the flake outputs
+      # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
+      packages.${system}.default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
+        modules = [
+          ./default.nix
+          {
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+
+      devShells.default = {
+        buildInputs = [ nixpkgs.nodejs_22 ];
+
+      };
+    };
+}

--- a/modules/raspiblitz-web.nix
+++ b/modules/raspiblitz-web.nix
@@ -1,0 +1,73 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  name = "blitz-web";
+  cfg = config.services.${name};
+
+  inherit (lib) mkOption mkIf mkEnableOption types literalExpression;
+in {
+  options = {
+    services.${name} = {
+      enable = mkEnableOption "${name}";
+
+      package = mkOption {
+        type = types.package;
+        defaultText = literalExpression "pkgs.${name}";
+        default = pkgs.${name};
+        description = "The ${name} package to use.";
+      };
+
+      nginx = {
+        enable = mkEnableOption "Whether to enable nginx server for ${name}.";
+        description = "This is used to generate the nginx configuration.";
+
+        hostName = mkOption {
+          type = types.str;
+          example = "my.node.net";
+          default = "localhost";
+          description = "The hostname to use for the nginx virtual host.";
+        };
+
+        location = mkOption {
+          type = types.str;
+          example = "/webui";
+          default = "/webui";
+          description = "The location to serve the webui fronted from.";
+        };
+
+        openFirewall = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Whether to open the ports used by ${name} in the firewall for the server";
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.static-web-server = {
+      enable = true;
+      root = "${pkgs.${name}}";
+      listen = "[::]:80";
+    };
+
+    # services.nginx = mkIf cfg.nginx.enable {
+    #   enable = true;
+    #   virtualHosts.${cfg.nginx.hostName} = {
+    #     forceSSL = false;
+    #     enableACME = false;
+    #
+    #     locations."${cfg.nginx.location}" = {
+    #       root = "${pkgs.${name}}";
+    #     };
+    #   };
+    # };
+
+    networking.firewall = mkIf cfg.nginx.openFirewall {
+      allowedTCPPorts = [80];
+    };
+  };
+}


### PR DESCRIPTION
## Added NixOS module 
Added a NixOS module in `modules/raspiblitz-web.nix` that allows RaspiBlitz Web UI to be deployed as a NixOS service 

## devenv.sh integration 
Added support for providing all necessary tools for development using devenv.sh.