### PR TITLE
adapt to API error handling changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # production
 /build
 dist
+/result
 
 # misc
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# devenv
+.devenv*

--- a/README.md
+++ b/README.md
@@ -20,12 +20,30 @@ Big thanks to our translators, which you can find in this [README](src/i18n/READ
 
 - [Node.js](https://nodejs.org/en/download/)
 - [asdf](https://asdf-vm.com/) is supported but not required.
+- [Nix](https://nixos.org/download.html) with [Flakes](https://nixos.wiki/wiki/Flakes) enabled (optional, for devenv.sh or NixOS builds)
 
 #### Update npm dependencies
 
 ```sh
 npm update
 ```
+
+### Development with devenv.sh
+
+This project supports [devenv.sh](https://devenv.sh/), a developer environment tool built on Nix.
+
+#### Setup
+
+1. Install devenv.sh by following the instructions at https://devenv.sh/getting-started/
+2. Run `devenv shell` to enter the development environment
+3. Devenv will install the npm dependencies automatically when entering the shell. To change this behaviour, change `javascript.npm.install.enable = true;` to `false` and run `npm install` after entering the shell.
+
+#### Benefits of using devenv.sh
+
+- Consistent development environment across all contributors
+- Automatically installs the correct version of Node.js and other dependencies
+- Includes development tools like TypeScript, ESLint, and Nix utilities
+- Works on any platform that supports Nix (Linux, macOS, WSL)
 
 ### Dev workflow
 

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,8 @@
-{ lib
-, config
-, dream2nix
-, ...
+{
+  lib,
+  config,
+  dream2nix,
+  ...
 }: {
   imports = [
     dream2nix.modules.dream2nix.nodejs-package-lock-v3
@@ -12,7 +13,7 @@
     src = ./build;
   };
 
-  deps = { nixpkgs, ... }: {
+  deps = {nixpkgs, ...}: {
     inherit
       (nixpkgs)
       stdenv

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, config
+, dream2nix
+, ...
+}: {
+  imports = [
+    dream2nix.modules.dream2nix.nodejs-package-lock-v3
+    dream2nix.modules.dream2nix.nodejs-granular-v3
+  ];
+
+  mkDerivation = {
+    src = ./build;
+  };
+
+  deps = { nixpkgs, ... }: {
+    inherit
+      (nixpkgs)
+      stdenv
+      ;
+  };
+
+  nodejs-package-lock-v3 = {
+    packageLockFile = "${config.mkDerivation.src}/package-lock.json";
+  };
+
+  name = "raspiblitz-web";
+  version = "1.3.0-dev";
+}

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,103 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1742320965,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "6bde92766ddd3ee1630029a03d36baddd51934e2",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742300892,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "ea26a82dda75bee6783baca6894040c8e6599728",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733477122,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "7bd9e84d0452f6d2e63b6e6da29fe73fac951857",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -27,6 +27,7 @@
   packages = [
     pkgs.typescript
     pkgs.eslint_d
+    pkgs.biome
     pkgs.vscode-js-debug
     pkgs.statix
     pkgs.alejandra

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,36 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}: {
+  # https://devenv.sh/languages/javascript/
+  languages = {
+    nix = {
+      enable = true;
+      lsp.package = pkgs.nixd;
+    };
+
+    javascript = {
+      enable = true;
+      npm = {
+        enable = true;
+        install.enable = true;
+      };
+    };
+
+    typescript = {
+      enable = true;
+    };
+  };
+
+  packages = [
+    pkgs.typescript
+    pkgs.eslint_d
+    pkgs.vscode-js-debug
+    pkgs.statix
+    pkgs.alejandra
+    pkgs.nixd
+    pkgs.statix
+  ];
+}

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716509168,
-        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
+        "lastModified": 1742288794,
+        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
+        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,112 @@
+{
+  "nodes": {
+    "dream2nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "purescript-overlay": "purescript-overlay",
+        "pyproject-nix": "pyproject-nix"
+      },
+      "locked": {
+        "lastModified": 1716662043,
+        "narHash": "sha256-RMw5XaEKQR7DQEFNr3f8G6Ce25ET/nafkEgY+goLoLU=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "b6a176f65988cd7a434783c938516884874d894e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716619601,
+        "narHash": "sha256-9dUxZf8MOqJH3vjbhrz7LH4qTcnRsPSBU1Q50T7q/X8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "47e03a624662ce399e55c45a5f6da698fc72c797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "purescript-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ],
+        "slimlock": "slimlock"
+      },
+      "locked": {
+        "lastModified": 1696022621,
+        "narHash": "sha256-eMjFmsj2G1E0Q5XiibUNgFjTiSz0GxIeSSzzVdoN730=",
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "rev": "047c7933abd6da8aa239904422e22d190ce55ead",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1702448246,
+        "narHash": "sha256-hFg5s/hoJFv7tDpiGvEvXP0UfFvFEDgTdyHIjDVHu1I=",
+        "owner": "davhau",
+        "repo": "pyproject.nix",
+        "rev": "5a06a2697b228c04dd2f35659b4b659ca74f7aeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "davhau",
+        "ref": "dream2nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "dream2nix": "dream2nix",
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ]
+      }
+    },
+    "slimlock": {
+      "inputs": {
+        "nixpkgs": [
+          "dream2nix",
+          "purescript-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688610262,
+        "narHash": "sha256-Wg0ViDotFWGWqKIQzyYCgayeH8s4U1OZcTiWTQYdAp4=",
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "rev": "b5c6cdcaf636ebbebd0a1f32520929394493f1a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,108 +1,57 @@
 {
   "nodes": {
-    "dream2nix": {
+    "flake-utils": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "purescript-overlay": "purescript-overlay",
-        "pyproject-nix": "pyproject-nix"
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1716662043,
-        "narHash": "sha256-RMw5XaEKQR7DQEFNr3f8G6Ce25ET/nafkEgY+goLoLU=",
-        "owner": "nix-community",
-        "repo": "dream2nix",
-        "rev": "b6a176f65988cd7a434783c938516884874d894e",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "repo": "dream2nix",
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716619601,
-        "narHash": "sha256-9dUxZf8MOqJH3vjbhrz7LH4qTcnRsPSBU1Q50T7q/X8=",
+        "lastModified": 1716509168,
+        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47e03a624662ce399e55c45a5f6da698fc72c797",
+        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "purescript-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "dream2nix",
-          "nixpkgs"
-        ],
-        "slimlock": "slimlock"
-      },
-      "locked": {
-        "lastModified": 1696022621,
-        "narHash": "sha256-eMjFmsj2G1E0Q5XiibUNgFjTiSz0GxIeSSzzVdoN730=",
-        "owner": "thomashoneyman",
-        "repo": "purescript-overlay",
-        "rev": "047c7933abd6da8aa239904422e22d190ce55ead",
-        "type": "github"
-      },
-      "original": {
-        "owner": "thomashoneyman",
-        "repo": "purescript-overlay",
-        "type": "github"
-      }
-    },
-    "pyproject-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1702448246,
-        "narHash": "sha256-hFg5s/hoJFv7tDpiGvEvXP0UfFvFEDgTdyHIjDVHu1I=",
-        "owner": "davhau",
-        "repo": "pyproject.nix",
-        "rev": "5a06a2697b228c04dd2f35659b4b659ca74f7aeb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "davhau",
-        "ref": "dream2nix",
-        "repo": "pyproject.nix",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "dream2nix": "dream2nix",
-        "nixpkgs": [
-          "dream2nix",
-          "nixpkgs"
-        ]
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
       }
     },
-    "slimlock": {
-      "inputs": {
-        "nixpkgs": [
-          "dream2nix",
-          "purescript-overlay",
-          "nixpkgs"
-        ]
-      },
+    "systems": {
       "locked": {
-        "lastModified": 1688610262,
-        "narHash": "sha256-Wg0ViDotFWGWqKIQzyYCgayeH8s4U1OZcTiWTQYdAp4=",
-        "owner": "thomashoneyman",
-        "repo": "slimlock",
-        "rev": "b5c6cdcaf636ebbebd0a1f32520929394493f1a6",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
-        "owner": "thomashoneyman",
-        "repo": "slimlock",
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "My flake with dream2nix packages";
+
+  inputs = {
+    dream2nix.url = "github:nix-community/dream2nix";
+    nixpkgs.follows = "dream2nix/nixpkgs";
+  };
+
+  outputs =
+    inputs @ { self
+    , dream2nix
+    , nixpkgs
+    , ...
+    }:
+    let
+      system = "x86_64-linux";
+    in
+    {
+      # All packages defined in ./packages/<name> are automatically added to the flake outputs
+      # e.g., 'packages/hello/default.nix' becomes '.#packages.hello'
+      packages.${system}.default = dream2nix.lib.evalModules {
+        packageSets.nixpkgs = inputs.dream2nix.inputs.nixpkgs.legacyPackages.${system};
+        modules = [
+          ./default.nix
+          {
+            paths.projectRoot = ./.;
+            # can be changed to ".git" or "flake.nix" to get rid of .project-root
+            paths.projectRootFile = "flake.nix";
+            paths.package = ./.;
+          }
+        ];
+      };
+
+      devShells.default = {
+        buildInputs = [ nixpkgs.nodejs_22 ];
+
+      };
+    };
+}

--- a/modules/raspiblitz-web.nix
+++ b/modules/raspiblitz-web.nix
@@ -1,0 +1,73 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  name = "blitz-web";
+  cfg = config.services.${name};
+
+  inherit (lib) mkOption mkIf mkEnableOption types literalExpression;
+in {
+  options = {
+    services.${name} = {
+      enable = mkEnableOption "${name}";
+
+      package = mkOption {
+        type = types.package;
+        defaultText = literalExpression "pkgs.${name}";
+        default = pkgs.${name};
+        description = "The ${name} package to use.";
+      };
+
+      nginx = {
+        enable = mkEnableOption "Whether to enable nginx server for ${name}.";
+        description = "This is used to generate the nginx configuration.";
+
+        hostName = mkOption {
+          type = types.str;
+          example = "my.node.net";
+          default = "localhost";
+          description = "The hostname to use for the nginx virtual host.";
+        };
+
+        location = mkOption {
+          type = types.str;
+          example = "/webui";
+          default = "/webui";
+          description = "The location to serve the webui fronted from.";
+        };
+
+        openFirewall = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Whether to open the ports used by ${name} in the firewall for the server";
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.static-web-server = {
+      enable = true;
+      root = "${pkgs.${name}}";
+      listen = "[::]:80";
+    };
+
+    # services.nginx = mkIf cfg.nginx.enable {
+    #   enable = true;
+    #   virtualHosts.${cfg.nginx.hostName} = {
+    #     forceSSL = false;
+    #     enableACME = false;
+    #
+    #     locations."${cfg.nginx.location}" = {
+    #       root = "${pkgs.${name}}";
+    #     };
+    #   };
+    # };
+
+    networking.firewall = mkIf cfg.nginx.openFirewall {
+      allowedTCPPorts = [80];
+    };
+  };
+}

--- a/src/context/sse-context.tsx
+++ b/src/context/sse-context.tsx
@@ -1,4 +1,4 @@
-import type { AppStatus } from "@/models/app-status";
+import type { AppStatus, AppStatusQueryResponse } from "@/models/app-status";
 import type { App } from "@/models/app.model";
 import type { BtcInfo } from "@/models/btc-info";
 import type { HardwareInfo } from "@/models/hardware-info";
@@ -27,8 +27,8 @@ export interface SSEContextType {
   balance: WalletBalance;
   setBalance: Dispatch<SetStateAction<WalletBalance>>;
 
-  appStatus: AppStatus[];
-  setAppStatus: Dispatch<SetStateAction<AppStatus[]>>;
+  appStatus: AppStatusQueryResponse;
+  setAppStatus: Dispatch<SetStateAction<AppStatusQueryResponse>>;
   availableApps: App[];
   setAvailableApps: Dispatch<SetStateAction<App[]>>;
   transactions: Transaction[];
@@ -54,7 +54,7 @@ export const sseContextDefault: SSEContextType = {
   lnInfo: {} as LnInfo,
   setLnInfo: () => {},
   setBalance: () => {},
-  appStatus: [],
+  appStatus: { data: [], errors: [], timestamp: 0 } as AppStatusQueryResponse,
   setAppStatus: () => {},
   availableApps: [],
   setAvailableApps: () => {},
@@ -131,7 +131,11 @@ const SSEContextProvider: FC<PropsWithChildren> = (props) => {
     channel_unsettled_local_balance: null,
     channel_unsettled_remote_balance: null,
   });
-  const [appStatus, setAppStatus] = useState<AppStatus[]>([]);
+  const [appStatus, setAppStatus] = useState<AppStatusQueryResponse>({
+    data: [],
+    errors: [],
+    age: 0,
+  });
   const [availableApps, setAvailableApps] = useState<App[]>([]);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>

--- a/src/i18n/langs/de.json
+++ b/src/i18n/langs/de.json
@@ -71,7 +71,12 @@
       "uninstall": "Deinstallieren",
       "uninstall_failure": "Deinstallation von {{appName}} fehlgeschlagen: {{details}}",
       "uninstall_success": "{{appName}} erfolgreich deinstalliert",
-      "uninstalling": "Deinstalliere"
+      "uninstalling": "Deinstalliere",
+      "error_occurred": "Ein Fehler ist aufgetreten",
+      "error_details": "Fehlerdetails",
+      "view_error": "Fehler anzeigen",
+      "copy": "Kopieren",
+      "close": "Schließen"
     },
     "forms": {
       "hint": {

--- a/src/i18n/langs/en.json
+++ b/src/i18n/langs/en.json
@@ -85,7 +85,25 @@
       "uninstall": "Uninstall",
       "uninstall_failure": "Uninstall of {{appName}} failed: {{details}}",
       "uninstall_success": "Successfully uninstalled {{appName}}",
-      "uninstalling": "Uninstalling"
+      "uninstalling": "Uninstalling",
+      "data_age": "Data age",
+      "age_just_now": "just now",
+      "age_less_than_minute": "<1 minute",
+      "age_minute": "{{minutes}} minute",
+      "age_minutes": "{{minutes}} minutes",
+      "age_hour": "{{hours}} hour",
+      "age_hours": "{{hours}} hours",
+      "refresh": "Refresh",
+      "refreshing": "Refreshing...",
+      "refresh_success": "App status refreshed successfully",
+      "refresh_error": "Failed to refresh app status",
+      "refresh_tooltip": "Shows how old the app data is",
+      "refresh_expensive_warning": "Use sparingly, its an expensive operation",
+      "error_occurred": "An error occurred",
+      "error_details": "Error Details",
+      "view_error": "View Error",
+      "copy": "Copy",
+      "close": "Close"
     },
     "forms": {
       "hint": {

--- a/src/layouts/SideDrawer.tsx
+++ b/src/layouts/SideDrawer.tsx
@@ -59,7 +59,7 @@ export const SideDrawer: FC = () => {
           </span>
         </NavLink>
 
-        {appStatus
+        {appStatus?.data
           .filter((app) => app.installed)
           .map((app) => (
             <AppStatusItem app={app} key={app.id} />

--- a/src/models/app-status.ts
+++ b/src/models/app-status.ts
@@ -1,14 +1,40 @@
+export interface AppStatusQueryResponse {
+  // successful queries
+  data: AppStatus[];
+  // failed queries
+  errors: AppQueryError[];
+  // unix timestamp (UTC) when the data was fetched
+  timestamp: number;
+}
+
 export interface AppStatus {
-  id: string;
+  id: AppId;
   installed: boolean;
   address?: string;
-  httpsForced?: "0" | "1";
-  httpsSelfsigned?: "0" | "1";
+  httpsForced?: boolean;
+  httpsSelfsigned?: boolean;
   hiddenService?: string;
   authMethod?: AuthMethod;
   details?: unknown;
-  error: string;
+  error?: string;
   version: string;
+}
+
+export interface AppQueryError {
+  id: AppId;
+  error: string;
+}
+
+export enum AppId {
+  ALBYHUB = "albyhub",
+  BTCPAYSERVER = "btcpayserver",
+  BTC_RPC_EXPLORER = "btc-rpc-explorer",
+  ELECTRS = "electrs",
+  JAM = "jam",
+  LNBITS = "lnbits",
+  MEMPOOL = "mempool",
+  RTL = "rtl",
+  THUNDERHUB = "thunderhub",
 }
 
 export enum AuthMethod {

--- a/src/pages/Apps/AppCard.tsx
+++ b/src/pages/Apps/AppCard.tsx
@@ -1,14 +1,16 @@
 import AppIcon from "@/components/AppIcon";
+import { ConfirmModal } from "@/components/ConfirmModal";
 import { type AppStatus, AuthMethod } from "@/models/app-status";
 import type { App } from "@/models/app.model";
 import { getHrefFromApp } from "@/utils";
 import {
   ArrowTopRightOnSquareIcon,
+  ExclamationTriangleIcon,
   InformationCircleIcon,
   LockOpenIcon,
   PlusIcon,
 } from "@heroicons/react/24/outline";
-import { Button, Link, Tooltip } from "@heroui/react";
+import { Button, Link, Tooltip, useDisclosure } from "@heroui/react";
 import { type FC, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
@@ -20,6 +22,7 @@ export type Props = {
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   installingApp: any | null;
   onInstall: (id: string) => void;
+  error?: string;
 };
 
 export const AppCard: FC<Props> = ({
@@ -28,11 +31,13 @@ export const AppCard: FC<Props> = ({
   installed,
   installingApp,
   onInstall,
+  error,
 }) => {
   const { id, name } = appInfo;
   const { t } = useTranslation();
   const [isInstallWaiting, setInstallWaiting] = useState(false);
   const navigate = useNavigate();
+  const errorModal = useDisclosure();
 
   useEffect(() => {
     setInstallWaiting(false);
@@ -58,8 +63,20 @@ export const AppCard: FC<Props> = ({
     }
   };
 
+  // Determine if the card should show an error state
+  const hasError = error || appStatusInfo.error;
+  const errorMessage = error || appStatusInfo.error;
+
+  const copyErrorToClipboard = () => {
+    if (errorMessage) {
+      navigator.clipboard.writeText(errorMessage);
+    }
+  };
+
   return (
-    <article className="bd-card bg-gray-800 transition-colors">
+    <article
+      className={`bd-card transition-colors ${hasError ? "border-red-500 border-2" : "bg-gray-800"}`}
+    >
       <div className="relative mt-2 flex h-4/6 w-full flex-row items-center">
         {installed && (
           <Tooltip
@@ -95,6 +112,58 @@ export const AppCard: FC<Props> = ({
         </div>
       </div>
 
+      {/* Error Message - Just show a brief indicator */}
+      {hasError && (
+        <div className="mt-2 mb-2 flex flex-row items-center gap-2 px-2 py-2 bg-red-900 bg-opacity-30 rounded-md">
+          <ExclamationTriangleIcon className="h-5 w-5 text-red-500" />
+          <p className="text-sm text-red-400 overflow-hidden text-ellipsis">
+            {t("apps.error_occurred")}
+          </p>
+        </div>
+      )}
+
+      {/* Error Modal */}
+      {hasError && (
+        <ConfirmModal
+          disclosure={errorModal}
+          headline={t("apps.error_details")}
+          custom
+        >
+          <ConfirmModal.Header>{t("apps.error_details")}</ConfirmModal.Header>
+          <ConfirmModal.Body>
+            <div className="max-h-[60vh] overflow-y-auto p-2 bg-gray-900 rounded-md font-mono text-sm">
+              {errorMessage}
+            </div>
+          </ConfirmModal.Body>
+          <ConfirmModal.Footer>
+            <Button onPress={errorModal.onClose}>{t("apps.close")}</Button>
+            <Button
+              color="primary"
+              onPress={copyErrorToClipboard}
+              startContent={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className="w-5 h-5"
+                >
+                  <title>{t("apps.copy")}</title>
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"
+                  />
+                </svg>
+              }
+            >
+              {t("apps.copy")}
+            </Button>
+          </ConfirmModal.Footer>
+        </ConfirmModal>
+      )}
+
       <div className="flex flex-row gap-2 py-4">
         {installed && appStatusInfo.address && !appInfo.customComponent && (
           <Button
@@ -127,9 +196,24 @@ export const AppCard: FC<Props> = ({
           </Button>
         )}
 
-        {(installingApp === null ||
-          installingApp.id !== id ||
-          installingApp.result === "fail") &&
+        {/* Show View Error button instead of Install button when there's an error */}
+        {hasError && !installed && (
+          <Button
+            onPress={errorModal.onOpen}
+            color="danger"
+            startContent={
+              <ExclamationTriangleIcon className="inline h-6 w-6" />
+            }
+          >
+            {t("apps.view_error")}
+          </Button>
+        )}
+
+        {/* Only show Install button when there's no error */}
+        {!hasError &&
+          (installingApp === null ||
+            installingApp.id !== id ||
+            installingApp.result === "fail") &&
           !installed && (
             <Button
               isDisabled={

--- a/src/pages/Apps/AppInfo.tsx
+++ b/src/pages/Apps/AppInfo.tsx
@@ -29,7 +29,7 @@ export const AppInfo: FC = () => {
   // biome-ignore lint/style/noNonNullAssertion: <explanation>
   const { author, repository } = availableApps[appId!];
   const { installed, version } =
-    appStatus.find((app) => app.id === appId) || {};
+    appStatus.data.find((app) => app.id === appId) || {};
 
   useEffect(() => {
     setIsLoading(true);

--- a/src/pages/Apps/AppPage.tsx
+++ b/src/pages/Apps/AppPage.tsx
@@ -13,7 +13,7 @@ export const AppInfo: FC = () => {
   // biome-ignore lint/style/noNonNullAssertion: <explanation>
   const { customComponent } = availableApps[appId!];
 
-  const app = appStatus.find((app) => app.id === appId);
+  const app = appStatus.data.find((app) => app.id === appId);
 
   useEffect(() => {
     setIsLoading(true);

--- a/src/pages/Apps/AppStatusRefresh.tsx
+++ b/src/pages/Apps/AppStatusRefresh.tsx
@@ -1,0 +1,124 @@
+import { SSEContext } from "@/context/sse-context";
+import { instance } from "@/utils/interceptor";
+import { ArrowPathIcon } from "@heroicons/react/24/outline";
+import { InformationCircleIcon } from "@heroicons/react/24/solid";
+import { Button, Tooltip } from "@heroui/react";
+import { useCallback, useContext, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "react-toastify";
+
+const AppStatusRefresh = () => {
+  const { t } = useTranslation();
+  const { appStatus } = useContext(SSEContext);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [formattedAge, setFormattedAge] = useState("");
+
+  useEffect(() => {
+    if (appStatus?.timestamp !== undefined) {
+      const updateTimestamp = appStatus.timestamp;
+      const currentTimestamp = Math.floor(Date.now() / 1000); // Current time in seconds
+      const ageInSeconds = currentTimestamp - updateTimestamp;
+
+      const formatAgeText = (seconds: number): string => {
+        if (seconds < 10) {
+          return t("apps.age_just_now");
+        }
+
+        // If less than 60 seconds, show "<1 minute ago"
+        if (seconds < 60) {
+          return t("apps.age_less_than_minute");
+        }
+
+        if (seconds < 3600) {
+          const minutes = Math.floor(seconds / 60);
+          return minutes === 1
+            ? t("apps.age_minute", { minutes })
+            : t("apps.age_minutes", { minutes });
+        }
+
+        const hours = Math.floor(seconds / 3600);
+        return hours === 1
+          ? t("apps.age_hour", { hours })
+          : t("apps.age_hours", { hours });
+      };
+
+      setFormattedAge(formatAgeText(ageInSeconds));
+
+      const intervalId = setInterval(() => {
+        const newCurrentTimestamp = Math.floor(Date.now() / 1000);
+        const newAgeInSeconds = newCurrentTimestamp - updateTimestamp;
+        setFormattedAge(formatAgeText(newAgeInSeconds));
+      }, 10000); // Update every 10 seconds
+
+      return () => clearInterval(intervalId);
+    }
+  }, [appStatus.timestamp, t]);
+
+  useEffect(() => {
+    const handleAppStateUpdating = () => {
+      setIsUpdating(true);
+    };
+
+    const handleAppStateUpdateSuccess = () => {
+      setIsUpdating(false);
+      toast.success(t("apps.refresh_success"));
+    };
+
+    window.addEventListener("app_state_updating", handleAppStateUpdating);
+    window.addEventListener(
+      "app_state_updating_success",
+      handleAppStateUpdateSuccess,
+    );
+
+    return () => {
+      window.removeEventListener("app_state_updating", handleAppStateUpdating);
+      window.removeEventListener(
+        "app_state_updating_success",
+        handleAppStateUpdateSuccess,
+      );
+    };
+  }, [t]);
+
+  const handleRefresh = useCallback(async () => {
+    if (isUpdating) return;
+
+    setIsUpdating(true);
+    try {
+      await instance.post("apps/update-cache");
+    } catch (error) {
+      setIsUpdating(false);
+      toast.error(t("apps.refresh_error"));
+      console.error("Error refreshing app status:", error);
+    }
+  }, [t, isUpdating]);
+
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center space-x-2">
+        <span className="text-sm text-gray-400">
+          {t("apps.data_age")}: {formattedAge}
+        </span>
+        <Tooltip content={t("apps.refresh_tooltip")}>
+          <InformationCircleIcon className="h-4 w-4 text-gray-400" />
+        </Tooltip>
+      </div>
+      <Tooltip
+        content={t("apps.refresh_expensive_warning")}
+        showArrow
+        placement="left"
+      >
+        <Button
+          color="primary"
+          size="sm"
+          isLoading={isUpdating}
+          onPress={handleRefresh}
+          startContent={<ArrowPathIcon className="h-5 w-5" />}
+        >
+          {isUpdating ? t("apps.refreshing") : t("apps.refresh")}
+        </Button>
+      </Tooltip>
+    </div>
+  );
+};
+
+export default AppStatusRefresh;

--- a/src/pages/Apps/customApps/Electrs.tsx
+++ b/src/pages/Apps/customApps/Electrs.tsx
@@ -56,7 +56,7 @@ const Electrs = () => {
 
   const { TORaddress, portSSL, localIP, version, initialSyncDone } = appData;
 
-  if (appStatus.find((app) => app.id === "electrs")?.installed === false) {
+  if (appStatus.data.find((app) => app.id === "electrs")?.installed === false) {
     navigate("/apps");
     return null;
   }

--- a/src/pages/Apps/index.tsx
+++ b/src/pages/Apps/index.tsx
@@ -5,33 +5,86 @@ import { enableGutter } from "@/utils";
 import { checkError } from "@/utils/checkError";
 import { instance } from "@/utils/interceptor";
 import type { FC } from "react";
-import { useContext, useEffect } from "react";
+import { useContext, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "react-toastify";
 import AppCardAlby from "./AppCardAlby";
 import AppList from "./AppList";
+import AppStatusRefresh from "./AppStatusRefresh";
 
 export const Apps: FC = () => {
   const { t } = useTranslation(["translation", "apps"]);
-  const { lnInfo } = useContext(SSEContext);
-  let { appStatus } = useContext(SSEContext);
+  const { lnInfo, appStatus } = useContext(SSEContext);
+  const [isUpdating, setIsUpdating] = useState(false);
 
   useEffect(() => {
     enableGutter();
   }, []);
 
+  // Listen to SSE events for app state updating
+  useEffect(() => {
+    const handleAppStateUpdating = () => {
+      setIsUpdating(true);
+    };
+
+    const handleAppStateUpdateSuccess = () => {
+      setIsUpdating(false);
+    };
+
+    // Add event listeners
+    window.addEventListener("app_state_updating", handleAppStateUpdating);
+    window.addEventListener(
+      "app_state_updating_success",
+      handleAppStateUpdateSuccess,
+    );
+
+    // Clean up event listeners
+    return () => {
+      window.removeEventListener("app_state_updating", handleAppStateUpdating);
+      window.removeEventListener(
+        "app_state_updating_success",
+        handleAppStateUpdateSuccess,
+      );
+    };
+  }, []);
+
   // alby hub only works on LND currently, so we filter the entry out on non LND nodes
-  if (lnInfo.implementation !== "LND_GRPC") {
-    appStatus = appStatus.filter((app: AppStatus) => app.id !== "albyhub");
-  }
+  const filteredAppData =
+    lnInfo.implementation !== "LND_GRPC"
+      ? appStatus.data.filter((app: AppStatus) => app.id !== "albyhub")
+      : appStatus.data;
 
   // on every render sort installed & uninstalled app keys
-  const installedApps = appStatus.filter((app: AppStatus) => {
+  const installedApps = filteredAppData.filter((app: AppStatus) => {
     return app.installed;
   });
-  const notInstalledApps = appStatus.filter((app: AppStatus) => {
+
+  const notInstalledApps = filteredAppData.filter((app: AppStatus) => {
     return !app.installed;
   });
+
+  // Create app status entries for apps that only have errors but no data entry
+  const errorOnlyApps: AppStatus[] = [];
+
+  // Process error-only apps that aren't already in data
+  if (appStatus.errors && appStatus.errors.length > 0) {
+    const existingAppIds = new Set(appStatus.data.map((app) => app.id));
+
+    for (const errorEntry of appStatus.errors) {
+      // Only add if this app isn't already in the data array
+      if (!existingAppIds.has(errorEntry.id)) {
+        errorOnlyApps.push({
+          id: errorEntry.id,
+          installed: false, // Assume not installed since we can't determine
+          version: "unknown", // Version can't be determined
+          error: errorEntry.error,
+        });
+      }
+    }
+  }
+
+  // Append error-only apps to the not installed apps list
+  const allNotInstalledApps = [...notInstalledApps, ...errorOnlyApps];
 
   const installHandler = (id: string) => {
     instance.post(`apps/install/${id}`).catch((err) => {
@@ -40,23 +93,29 @@ export const Apps: FC = () => {
   };
 
   // in case no App data received yet => show loading screen
-  if (appStatus.length === 0) {
+  if (appStatus.data.length === 0) {
     return <PageLoadingScreen />;
   }
 
   return (
     <main className="content-container page-container bg-gray-700 p-5 text-white transition-colors lg:pb-8 lg:pr-8 lg:pt-8">
       <>
+        <AppStatusRefresh />
+
         <AppList
           apps={installedApps}
           title={t("apps.installed")}
           onInstall={installHandler}
+          errors={appStatus.errors}
         />
+
         <AppList
-          apps={notInstalledApps}
+          apps={allNotInstalledApps}
           title={t("apps.available")}
           onInstall={installHandler}
+          errors={appStatus.errors}
         />
+
         <section className="flex h-full flex-wrap pt-8">
           <div className="grid w-full grid-cols-1 gap-5 lg:grid-cols-3 lg:gap-8">
             <AppCardAlby />


### PR DESCRIPTION
I've updated the apps page (well, Goose did ...) to work with the latest changes of how the API returns the data. This PR only works with [123_error_handling](https://github.com/fusion44/blitz_api/tree/123_error_handling/) branch of the API.

The UI basically works as before, but displays the age of the data. The API now returns a cached version instantly instead of fetching it on each new connection. 

I've added a force refresh button to force the API to refresh the data, which it does automatically every 30 minutes at the moment and pushed the result via the SSE/websocket connection. Should probably be more like 5 minutes or something. 

![image](https://github.com/user-attachments/assets/11b72458-5ce0-49f0-a905-c1f2f38a422f)

Since the API reports error more directly I've also changed how errors are handled when the script call was not successful when and no data could be fetched:
![image](https://github.com/user-attachments/assets/2f41e534-808e-4650-a3d5-1359e1d7631f)

When the show error button is clicked:
![image](https://github.com/user-attachments/assets/68470c14-c9b1-4a47-86fd-0dc3e85b2525)

requires #826 